### PR TITLE
migrate to map structure of table

### DIFF
--- a/src/test/java/com/axibase/tsd/api/model/sql/ColumnMetaData.java
+++ b/src/test/java/com/axibase/tsd/api/model/sql/ColumnMetaData.java
@@ -1,0 +1,71 @@
+package com.axibase.tsd.api.model.sql;
+
+/**
+ * @author Igor Shmagrinskiy
+ */
+public class ColumnMetaData implements Comparable<ColumnMetaData> {
+    private String name;
+    private Integer columnIndex;
+    private String table;
+    private String dataType;
+    private String propertyUrl;
+    private String titles;
+
+
+    public ColumnMetaData(String name, Integer columnIndex) {
+        this.name = name;
+        this.columnIndex = columnIndex;
+    }
+
+    public Integer getColumnIndex() {
+        return columnIndex;
+    }
+
+    private void setColumnIndex(Integer columnIndex) {
+        this.columnIndex = columnIndex;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getTitles() {
+        return titles;
+    }
+
+    public void setTitles(String titles) {
+        this.titles = titles;
+    }
+
+    public String getPropertyUrl() {
+        return propertyUrl;
+    }
+
+    public void setPropertyUrl(String propertyUrl) {
+        this.propertyUrl = propertyUrl;
+    }
+
+    public String getDataType() {
+        return dataType;
+    }
+
+    public void setDataType(String dataType) {
+        this.dataType = dataType;
+    }
+
+    public String getTable() {
+        return table;
+    }
+
+    public void setTable(String table) {
+        this.table = table;
+    }
+
+    @Override
+    public int compareTo(ColumnMetaData o) {
+        if (o == null) {
+            throw new NullPointerException();
+        }
+        return this.columnIndex.compareTo(o.getColumnIndex());
+    }
+}

--- a/src/test/java/com/axibase/tsd/api/model/sql/ColumnMetaData.java
+++ b/src/test/java/com/axibase/tsd/api/model/sql/ColumnMetaData.java
@@ -63,9 +63,6 @@ public class ColumnMetaData implements Comparable<ColumnMetaData> {
 
     @Override
     public int compareTo(ColumnMetaData o) {
-        if (o == null) {
-            throw new NullPointerException();
-        }
         return this.columnIndex.compareTo(o.getColumnIndex());
     }
 }


### PR DESCRIPTION
## Changes
-  added new column class, that the only determines a table column
  -  this class contain meta data about every column
-  StringTable  migrated to  map structure.

### Tasks from review

- [x] `compareTo` should return null or throw an exception.
- [x] Fix javadocs in `StringTableDeserializer`.
- [x] Implement `Comaparable<ColumnMetaData>` instead `Comparable` in `ColumnMetaData` class.
- [x] remove NPE handling in `compareTo`. 