### PR TITLE
2850 bug

### DIFF
--- a/src/test/java/com/axibase/tsd/api/Util.java
+++ b/src/test/java/com/axibase/tsd/api/Util.java
@@ -35,15 +35,20 @@ public class Util {
     }
 
     public static String ISOFormat(Date date) {
-        SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXXX");
-        dateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
-        return dateFormat.format(date);
+        return ISOFormat(date, true, "UTC");
     }
 
     public static String ISOFormat(long t) {
-        Calendar calendar = Calendar.getInstance();
-        calendar.setTimeInMillis(t);
-        return ISOFormat(calendar.getTime());
+        return ISOFormat(new Date(t));
+    }
+    public static String ISOFormat(long t, boolean withMillis, String timeZoneName) {
+        return ISOFormat(new Date(t), withMillis, timeZoneName);
+    }
+    public static String ISOFormat(Date date, boolean withMillis, String timeZoneName) {
+        String pattern = (withMillis) ? "yyyy-MM-dd'T'HH:mm:ss.SSSXXX" : "yyyy-MM-dd'T'HH:mm:ssXXX";
+        SimpleDateFormat dateFormat = new SimpleDateFormat(pattern);
+        dateFormat.setTimeZone(TimeZone.getTimeZone(timeZoneName));
+        return dateFormat.format(date);
     }
 
     public static Date parseDate(String date) {

--- a/src/test/java/com/axibase/tsd/api/Util.java
+++ b/src/test/java/com/axibase/tsd/api/Util.java
@@ -61,14 +61,6 @@ public class Util {
         return d;
     }
 
-    public static String getMinDate() {
-        return "1970-01-01T00:00:00Z";
-    }
-
-    public static String getMaxDate() {
-        return "9999-01-01T00:00:00Z";
-    }
-
 
     public static class ABNF {
         private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());

--- a/src/test/java/com/axibase/tsd/api/Util.java
+++ b/src/test/java/com/axibase/tsd/api/Util.java
@@ -76,27 +76,6 @@ public class Util {
             for (int i = 97; i < 122; i++) { //a-z
                 pool.add((char) i);
             }
-
-//            for (int i = 0x21; i < 0x7e; i++) { //visible character
-//                pool.add((char) i);
-//            }
-
-//            for (int i = 0x80; i < 0xFF; i++) { //Latin-1 Supplement
-//                pool.add((char) i);
-//            }
-
-//            for (int i = 0x100; i < 0x17F; i++) { //Latin Extended-A
-//                pool.add((char) i);
-//            }
-//
-//            for (int i = 0x370; i < 0x52F; i++) { //Greek and Coptic, Cyrillic, Cyrillic Supplement
-//                pool.add((char) i);
-//            }
-
-//            for (int i = 0x4E00; i < 0x4E5F; i++) {//9FFF; i++) { //CJK Unified Ideographs
-//                pool.add((char) i);
-//            }
-//            logger.debug("visible character pool: {}", pool);
             return pool;
 
         }

--- a/src/test/java/com/axibase/tsd/api/method/csv/CSVUploadTest.java
+++ b/src/test/java/com/axibase/tsd/api/method/csv/CSVUploadTest.java
@@ -244,7 +244,7 @@ public class CSVUploadTest extends CSVUploadMethod {
 
         Thread.sleep(1000L);
 
-        SeriesQuery seriesQuery = new SeriesQuery(entityName, metricName, Util.getMinDate(), Util.getMaxDate());
+        SeriesQuery seriesQuery = new SeriesQuery(entityName, metricName, Util.MIN_STORABLE_DATE, Util.MAX_QUERYABLE_DATE);
         JSONArray storedSeriesList = SeriesMethod.executeQuery(seriesQuery);
         assertSeriesValue(entityName, metricName, "2016-06-19T00:00:00.000Z", "123.45", storedSeriesList);
     }
@@ -259,7 +259,7 @@ public class CSVUploadTest extends CSVUploadMethod {
 
         Thread.sleep(1000L);
 
-        SeriesQuery seriesQuery = new SeriesQuery(entityName, metricName, Util.getMinDate(), Util.getMaxDate());
+        SeriesQuery seriesQuery = new SeriesQuery(entityName, metricName, Util.MIN_STORABLE_DATE, Util.MAX_QUERYABLE_DATE);
         JSONArray storedSeriesList = SeriesMethod.executeQuery(seriesQuery);
         assertSeriesValue(entityName, metricName, "2016-06-19T00:00:00.000Z", "123.45", storedSeriesList);
     }

--- a/src/test/java/com/axibase/tsd/api/method/csv/ParserEncodingTest.java
+++ b/src/test/java/com/axibase/tsd/api/method/csv/ParserEncodingTest.java
@@ -71,8 +71,8 @@ public class ParserEncodingTest extends CSVUploadMethod {
 
         MessageQuery messageQuery = new MessageQuery();
         messageQuery.setEntity(entityName);
-        messageQuery.setStartDate(Util.getMinDate());
-        messageQuery.setEndDate(Util.getMaxDate());
+        messageQuery.setStartDate(Util.MIN_QUERYABLE_DATE);
+        messageQuery.setEndDate(Util.MAX_QUERYABLE_DATE);
         List<Message> storedMessageList = MessageMethod.executeQuery(messageQuery).readEntity(new GenericType<List<Message>>(){});
 
         assertEquals("Unexpected message body", controlSequence, storedMessageList.get(0).getMessage());

--- a/src/test/java/com/axibase/tsd/api/method/csv/ParserEncodingTest.java
+++ b/src/test/java/com/axibase/tsd/api/method/csv/ParserEncodingTest.java
@@ -69,7 +69,10 @@ public class ParserEncodingTest extends CSVUploadMethod {
 
         Thread.sleep(1000L);
 
-        MessageQuery messageQuery = new MessageQuery(entityName, Util.getMinDate(), Util.getMaxDate());
+        MessageQuery messageQuery = new MessageQuery();
+        messageQuery.setEntity(entityName);
+        messageQuery.setStartDate(Util.getMinDate());
+        messageQuery.setEndDate(Util.getMaxDate());
         List<Message> storedMessageList = MessageMethod.executeQuery(messageQuery).readEntity(new GenericType<List<Message>>(){});
 
         assertEquals("Unexpected message body", controlSequence, storedMessageList.get(0).getMessage());

--- a/src/test/java/com/axibase/tsd/api/method/message/MessageCommandTest.java
+++ b/src/test/java/com/axibase/tsd/api/method/message/MessageCommandTest.java
@@ -5,8 +5,6 @@ import com.axibase.tsd.api.model.message.MessageQuery;
 import org.json.JSONException;
 import org.junit.Assert;
 import org.junit.Test;
-import org.skyscreamer.jsonassert.JSONAssert;
-import org.skyscreamer.jsonassert.JSONCompareMode;
 
 import java.io.IOException;
 import java.text.ParseException;
@@ -47,7 +45,10 @@ public class MessageCommandTest extends MessageMethod {
         Assert.assertEquals("Command length is not maximal", MAX_LENGTH, sb.length());
         tcpSender.send(sb.toString(), 1000);
 
-        MessageQuery messageQuery = new MessageQuery(message.getEntity(), startDate, endDate);
+        MessageQuery messageQuery = new MessageQuery();
+        messageQuery.setEntity(message.getEntity());
+        messageQuery.setStartDate(startDate);
+        messageQuery.setEndDate(endDate);
         messageQuery.setType(message.getType());
         messageQuery.setSource(message.getSource());
         messageQuery.setSeverity(message.getSeverity());
@@ -92,7 +93,10 @@ public class MessageCommandTest extends MessageMethod {
         }
         tcpSender.send(sb.toString(), 1000);
 
-        MessageQuery messageQuery = new MessageQuery(message.getEntity(), startDate, endDate);
+        MessageQuery messageQuery = new MessageQuery();
+        messageQuery.setEntity(message.getEntity());
+        messageQuery.setStartDate(startDate);
+        messageQuery.setEndDate(endDate);
         messageQuery.setType(message.getType());
         messageQuery.setSource(message.getSource());
         messageQuery.setSeverity(message.getSeverity());

--- a/src/test/java/com/axibase/tsd/api/method/message/MessageInsertTest.java
+++ b/src/test/java/com/axibase/tsd/api/method/message/MessageInsertTest.java
@@ -1,7 +1,7 @@
 package com.axibase.tsd.api.method.message;
 
 import com.axibase.tsd.api.model.Interval;
-import com.axibase.tsd.api.model.IntervalUnit;
+import com.axibase.tsd.api.model.TimeUnit;
 import com.axibase.tsd.api.model.message.Message;
 import com.axibase.tsd.api.model.message.MessageQuery;
 import org.junit.Assert;
@@ -125,14 +125,14 @@ public class MessageInsertTest extends MessageMethod {
         MessageQuery messageQuery = new MessageQuery();
         messageQuery.setEntity(entityName);
         messageQuery.setStartDate(date);
-        messageQuery.setInterval(new Interval(1, IntervalUnit.MILLISECOND));
+        messageQuery.setInterval(new Interval(1, TimeUnit.MILLISECOND));
 
         List<Message> storedMessageList = executeQuery(messageQuery).readEntity(new GenericType<List<Message>>(){});
         Message storedMessage = storedMessageList.get(0);
 
-        assertEquals(message.getEntity(), storedMessage.getEntity());
-        assertEquals(message.getMessage(), storedMessage.getMessage());
-        assertEquals(date, storedMessage.getDate());
+        assertEquals("Incorrect message entity", message.getEntity(), storedMessage.getEntity());
+        assertEquals("Incorrect message text", message.getMessage(), storedMessage.getMessage());
+        assertEquals("Incorrect message date", date, storedMessage.getDate());
     }
 
     /* #2850 */
@@ -149,14 +149,14 @@ public class MessageInsertTest extends MessageMethod {
         MessageQuery messageQuery = new MessageQuery();
         messageQuery.setEntity(entityName);
         messageQuery.setStartDate(date);
-        messageQuery.setInterval(new Interval(1, IntervalUnit.MILLISECOND));
+        messageQuery.setInterval(new Interval(1, TimeUnit.MILLISECOND));
 
         List<Message> storedMessageList = executeQuery(messageQuery).readEntity(new GenericType<List<Message>>(){});
         Message storedMessage = storedMessageList.get(0);
 
-        assertEquals(message.getEntity(), storedMessage.getEntity());
-        assertEquals(message.getMessage(), storedMessage.getMessage());
-        assertEquals(date, storedMessage.getDate());
+        assertEquals("Incorrect message entity", message.getEntity(), storedMessage.getEntity());
+        assertEquals("Incorrect message text", message.getMessage(), storedMessage.getMessage());
+        assertEquals("Incorrect message date", date, storedMessage.getDate());
     }
 
     /* #2850 */
@@ -173,14 +173,14 @@ public class MessageInsertTest extends MessageMethod {
         MessageQuery messageQuery = new MessageQuery();
         messageQuery.setEntity(entityName);
         messageQuery.setStartDate(date);
-        messageQuery.setInterval(new Interval(1, IntervalUnit.MILLISECOND));
+        messageQuery.setInterval(new Interval(1, TimeUnit.MILLISECOND));
 
         List<Message> storedMessageList = executeQuery(messageQuery).readEntity(new GenericType<List<Message>>(){});
         Message storedMessage = storedMessageList.get(0);
 
-        assertEquals(message.getEntity(), storedMessage.getEntity());
-        assertEquals(message.getMessage(), storedMessage.getMessage());
-        assertEquals(date, storedMessage.getDate());
+        assertEquals("Incorrect message entity", message.getEntity(), storedMessage.getEntity());
+        assertEquals("Incorrect message text", message.getMessage(), storedMessage.getMessage());
+        assertEquals("Incorrect message date", date, storedMessage.getDate());
     }
 
     /* #2850 */
@@ -192,7 +192,7 @@ public class MessageInsertTest extends MessageMethod {
 
         Response response = insertMessageReturnResponse(message);
 
-        assertEquals(BAD_REQUEST.getStatusCode(), response.getStatus());
+        assertEquals("Incorrect response status code", BAD_REQUEST.getStatusCode(), response.getStatus());
         JSONAssert.assertEquals("{\"error\":\"IllegalArgumentException: Failed to parse date 2016-07-21 00:00:00\"}", response.readEntity(String.class), true);
 
     }
@@ -206,7 +206,7 @@ public class MessageInsertTest extends MessageMethod {
 
         Response response = insertMessageReturnResponse(message);
 
-        assertEquals(BAD_REQUEST.getStatusCode(), response.getStatus());
+        assertEquals("Incorrect response status code", BAD_REQUEST.getStatusCode(), response.getStatus());
         JSONAssert.assertEquals("{\"error\":\"IllegalArgumentException: Failed to parse date 2016-07-20T22:50:00-0110\"}", response.readEntity(String.class), true);
     }
 
@@ -219,7 +219,7 @@ public class MessageInsertTest extends MessageMethod {
 
         Response response = insertMessageReturnResponse(message);
 
-        assertEquals(BAD_REQUEST.getStatusCode(), response.getStatus());
+        assertEquals("Incorrect response status code", BAD_REQUEST.getStatusCode(), response.getStatus());
         JSONAssert.assertEquals("{\"error\":\"IllegalArgumentException: Failed to parse date 1469059200000\"}", response.readEntity(String.class), true);
     }
 

--- a/src/test/java/com/axibase/tsd/api/method/message/MessageInsertTest.java
+++ b/src/test/java/com/axibase/tsd/api/method/message/MessageInsertTest.java
@@ -1,6 +1,5 @@
 package com.axibase.tsd.api.method.message;
 
-import com.axibase.tsd.api.Util;
 import com.axibase.tsd.api.model.Interval;
 import com.axibase.tsd.api.model.IntervalUnit;
 import com.axibase.tsd.api.model.message.Message;
@@ -14,7 +13,6 @@ import javax.ws.rs.core.Response;
 import java.util.List;
 
 import static com.axibase.tsd.api.Util.*;
-
 import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
 import static org.junit.Assert.assertEquals;
 
@@ -43,9 +41,9 @@ public class MessageInsertTest extends MessageMethod {
         });
         Message storedMessage = storedMessageList.get(0);
 
-        Assert.assertEquals("nurswgvml022", storedMessage.getEntity());
-        Assert.assertEquals("NURSWGVML007 ssh: error: connect_to localhost port 8881: failed.", storedMessage.getMessage());
-        Assert.assertEquals("application", storedMessage.getType());
+        assertEquals("nurswgvml022", storedMessage.getEntity());
+        assertEquals("NURSWGVML007 ssh: error: connect_to localhost port 8881: failed.", storedMessage.getMessage());
+        assertEquals("application", storedMessage.getType());
     }
 
     /* #2957 */
@@ -69,8 +67,8 @@ public class MessageInsertTest extends MessageMethod {
         List<Message> storedMessageList = executeQuery(messageQuery).readEntity(new GenericType<List<Message>>() {});
 
         Message msgResponse = storedMessageList.get(0);
-        Assert.assertEquals("Incorrect stored date", message.getDate(), msgResponse.getDate());
-        Assert.assertEquals("Incorrect stored message", message.getMessage(), msgResponse.getMessage());
+        assertEquals("Incorrect stored date", message.getDate(), msgResponse.getDate());
+        assertEquals("Incorrect stored message", message.getMessage(), msgResponse.getMessage());
     }
 
     /* #2957 */
@@ -113,76 +111,82 @@ public class MessageInsertTest extends MessageMethod {
             Assert.fail("Managed to insert message with date out of range");
     }
 
+    /* #2850 */
     @Test
     public void testISOTimezoneZ() throws Exception {
-        long startMillis = 1463788800000L;
-
-        Message message = new Message("message-insert-test-isoz");
+        String entityName = "message-insert-test-isoz";
+        Message message = new Message(entityName);
         message.setMessage("hello");
-        message.setDate(Util.ISOFormat(startMillis, false, "UTC"));
+        message.setDate("2016-05-21T00:00:00Z");
 
         Assert.assertTrue("Fail to insert message", insertMessage(message, 1000));
 
+        String date = "2016-05-21T00:00:00.000Z";
         MessageQuery messageQuery = new MessageQuery();
-        messageQuery.setEntity("message-insert-test-isoz");
-        messageQuery.setStartDate(Util.ISOFormat(startMillis, false, "UTC"));
-        messageQuery.setInterval(new Interval(1, IntervalUnit.SECOND));
+        messageQuery.setEntity(entityName);
+        messageQuery.setStartDate(date);
+        messageQuery.setInterval(new Interval(1, IntervalUnit.MILLISECOND));
+
         List<Message> storedMessageList = executeQuery(messageQuery).readEntity(new GenericType<List<Message>>(){});
         Message storedMessage = storedMessageList.get(0);
 
-        Assert.assertEquals(message.getEntity(), storedMessage.getEntity());
-        Assert.assertEquals(message.getMessage(), storedMessage.getMessage());
-        Assert.assertEquals(Util.ISOFormat(startMillis, true, "UTC"), storedMessage.getDate());
+        assertEquals(message.getEntity(), storedMessage.getEntity());
+        assertEquals(message.getMessage(), storedMessage.getMessage());
+        assertEquals(date, storedMessage.getDate());
     }
 
+    /* #2850 */
     @Test
     public void testISOTimezonePlusHourMinute() throws Exception {
-        long startMillis = 1463788800000L;
-
-        Message message = new Message("message-insert-test-iso+hm");
+        String entityName = "message-insert-test-iso+hm";
+        Message message = new Message(entityName);
         message.setMessage("hello");
-        message.setDate(Util.ISOFormat(startMillis, false, "GMT+01:23"));
+        message.setDate("2016-05-21T01:23:00+01:23");
 
         Assert.assertTrue("Fail to insert message", insertMessage(message, 1000));
 
+        String date = "2016-05-21T00:00:00.000Z";
         MessageQuery messageQuery = new MessageQuery();
-        messageQuery.setEntity("message-insert-test-iso+hm");
-        messageQuery.setStartDate(Util.ISOFormat(startMillis, false, "UTC"));
-        messageQuery.setInterval(new Interval(1, IntervalUnit.SECOND));
+        messageQuery.setEntity(entityName);
+        messageQuery.setStartDate(date);
+        messageQuery.setInterval(new Interval(1, IntervalUnit.MILLISECOND));
+
         List<Message> storedMessageList = executeQuery(messageQuery).readEntity(new GenericType<List<Message>>(){});
         Message storedMessage = storedMessageList.get(0);
 
-        Assert.assertEquals(message.getEntity(), storedMessage.getEntity());
-        Assert.assertEquals(message.getMessage(), storedMessage.getMessage());
-        Assert.assertEquals(Util.ISOFormat(startMillis, true, "UTC"), storedMessage.getDate());
+        assertEquals(message.getEntity(), storedMessage.getEntity());
+        assertEquals(message.getMessage(), storedMessage.getMessage());
+        assertEquals(date, storedMessage.getDate());
     }
 
+    /* #2850 */
     @Test
     public void testISOTimezoneMinusHourMinute() throws Exception {
-        long startMillis = 1463788800000L;
-
-        Message message = new Message("message-insert-test-iso-hm");
+        String entityName = "message-insert-test-iso-hm";
+        Message message = new Message(entityName);
         message.setMessage("hello");
-        message.setDate(Util.ISOFormat(startMillis, false, "GMT-01:23"));
+        message.setDate("2016-05-20T22:37:00-01:23");
 
         Assert.assertTrue("Fail to insert message", insertMessage(message, 1000));
 
+        String date = "2016-05-21T00:00:00.000Z";
         MessageQuery messageQuery = new MessageQuery();
-        messageQuery.setEntity("message-insert-test-iso-hm");
-        messageQuery.setStartDate(Util.ISOFormat(startMillis, false, "UTC"));
-        messageQuery.setInterval(new Interval(1, IntervalUnit.SECOND));
+        messageQuery.setEntity(entityName);
+        messageQuery.setStartDate(date);
+        messageQuery.setInterval(new Interval(1, IntervalUnit.MILLISECOND));
+
         List<Message> storedMessageList = executeQuery(messageQuery).readEntity(new GenericType<List<Message>>(){});
         Message storedMessage = storedMessageList.get(0);
 
-        Assert.assertEquals(message.getEntity(), storedMessage.getEntity());
-        Assert.assertEquals(message.getMessage(), storedMessage.getMessage());
-        Assert.assertEquals(Util.ISOFormat(startMillis, true, "UTC"), storedMessage.getDate());
+        assertEquals(message.getEntity(), storedMessage.getEntity());
+        assertEquals(message.getMessage(), storedMessage.getMessage());
+        assertEquals(date, storedMessage.getDate());
     }
 
+    /* #2850 */
     @Test
     public void testLocalTimeUnsupported() throws Exception {
-        String entityName = "message-insert-test-localtime";
-        Message message = new Message(entityName);
+        Message message = new Message("message-insert-test-localtime");
         message.setMessage("hello");
         message.setDate("2016-07-21 00:00:00");
 
@@ -192,10 +196,11 @@ public class MessageInsertTest extends MessageMethod {
         JSONAssert.assertEquals("{\"error\":\"IllegalArgumentException: Failed to parse date 2016-07-21 00:00:00\"}", response.readEntity(String.class), true);
 
     }
+
+    /* #2850 */
     @Test
     public void testXXTimezoneUnsupported() throws Exception {
-        String entityName = "message-insert-test-xxtimezone";
-        Message message = new Message(entityName);
+        Message message = new Message("message-insert-test-xxtimezone");
         message.setMessage("hello");
         message.setDate("2016-07-20T22:50:00-0110");
 
@@ -204,10 +209,11 @@ public class MessageInsertTest extends MessageMethod {
         assertEquals(BAD_REQUEST.getStatusCode(), response.getStatus());
         JSONAssert.assertEquals("{\"error\":\"IllegalArgumentException: Failed to parse date 2016-07-20T22:50:00-0110\"}", response.readEntity(String.class), true);
     }
+
+    /* #2850 */
     @Test
     public void testMillisecondsUnsupported() throws Exception {
-        String entityName = "message-insert-test-milliseconds";
-        Message message = new Message(entityName);
+        Message message = new Message("message-insert-test-milliseconds");
         message.setMessage("hello");
         message.setDate("1469059200000");
 

--- a/src/test/java/com/axibase/tsd/api/method/message/MessageMethod.java
+++ b/src/test/java/com/axibase/tsd/api/method/message/MessageMethod.java
@@ -7,7 +7,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.ws.rs.client.Entity;
-import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.io.IOException;
 import java.lang.invoke.MethodHandles;
@@ -21,6 +20,15 @@ public class MessageMethod extends BaseMethod {
 
     static final String METHOD_MESSAGE_INSERT = "/messages/insert";
     static final String METHOD_MESSAGE_QUERY = "/messages/query";
+
+    public static Response insertMessageReturnResponse(final Message message) {
+        return insertMessageReturnResponse(Collections.singletonList(message));
+    }
+    public static Response insertMessageReturnResponse(List<Message> messageList) {
+        Response response = httpApiResource.path(METHOD_MESSAGE_INSERT).request().post(Entity.json(messageList));
+        response.bufferEntity();
+        return response;
+    }
 
     public static Boolean insertMessage(final Message message, long sleepDuration) throws IOException, InterruptedException {
         return insertMessage(Collections.singletonList(message), sleepDuration);

--- a/src/test/java/com/axibase/tsd/api/method/message/MessageQueryTest.java
+++ b/src/test/java/com/axibase/tsd/api/method/message/MessageQueryTest.java
@@ -1,0 +1,141 @@
+package com.axibase.tsd.api.method.message;
+
+import com.axibase.tsd.api.Util;
+import com.axibase.tsd.api.model.Interval;
+import com.axibase.tsd.api.model.IntervalUnit;
+import com.axibase.tsd.api.model.message.Message;
+import com.axibase.tsd.api.model.message.MessageQuery;
+import org.junit.Assert;
+import org.junit.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
+
+import javax.ws.rs.core.GenericType;
+import javax.ws.rs.core.Response;
+import java.util.List;
+
+import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
+import static org.junit.Assert.assertEquals;
+
+public class MessageQueryTest extends MessageMethod {
+    @Test
+    public void testISOTimezoneZ() throws Exception {
+        long startMillis = 1463788800000L;
+
+        Message message = new Message("message-query-test-isoz");
+        message.setMessage("hello");
+        message.setDate(Util.ISOFormat(startMillis, false, "UTC"));
+
+        Assert.assertTrue("Fail to insert message", insertMessage(message, 1000));
+
+        MessageQuery messageQuery = new MessageQuery();
+        messageQuery.setEntity("message-query-test-isoz");
+        messageQuery.setStartDate(Util.ISOFormat(startMillis, false, "UTC"));
+        messageQuery.setInterval(new Interval(1, IntervalUnit.SECOND));
+        List<Message> storedMessageList = executeQuery(messageQuery).readEntity(new GenericType<List<Message>>(){});
+        Message storedMessage = storedMessageList.get(0);
+
+        Assert.assertEquals(message.getEntity(), storedMessage.getEntity());
+        Assert.assertEquals(message.getMessage(), storedMessage.getMessage());
+        Assert.assertEquals(Util.ISOFormat(startMillis, true, "UTC"), storedMessage.getDate());
+    }
+
+    @Test
+    public void testISOTimezonePlusHourMinute() throws Exception {
+        long startMillis = 1463788800000L;
+
+        Message message = new Message("message-query-test-iso+hm");
+        message.setMessage("hello");
+        message.setDate(Util.ISOFormat(startMillis, false, "UTC"));
+
+        Assert.assertTrue("Fail to insert message", insertMessage(message, 1000));
+
+        MessageQuery messageQuery = new MessageQuery();
+        messageQuery.setEntity("message-query-test-iso+hm");
+        messageQuery.setStartDate(Util.ISOFormat(startMillis, false, "GMT+01:23"));
+        messageQuery.setInterval(new Interval(1, IntervalUnit.SECOND));
+        List<Message> storedMessageList = executeQuery(messageQuery).readEntity(new GenericType<List<Message>>(){});
+        Message storedMessage = storedMessageList.get(0);
+
+        Assert.assertEquals(message.getEntity(), storedMessage.getEntity());
+        Assert.assertEquals(message.getMessage(), storedMessage.getMessage());
+        Assert.assertEquals(Util.ISOFormat(startMillis, true, "UTC"), storedMessage.getDate());
+    }
+
+    @Test
+    public void testISOTimezoneMinusHourMinute() throws Exception {
+        long startMillis = 1463788800000L;
+
+        Message message = new Message("message-query-test-iso-hm");
+        message.setMessage("hello");
+        message.setDate(Util.ISOFormat(startMillis, false, "UTC"));
+
+        Assert.assertTrue("Fail to insert message", insertMessage(message, 1000));
+
+        MessageQuery messageQuery = new MessageQuery();
+        messageQuery.setEntity("message-query-test-iso-hm");
+        messageQuery.setStartDate(Util.ISOFormat(startMillis, false, "GMT-01:23"));
+        messageQuery.setInterval(new Interval(1, IntervalUnit.SECOND));
+        List<Message> storedMessageList = executeQuery(messageQuery).readEntity(new GenericType<List<Message>>(){});
+        Message storedMessage = storedMessageList.get(0);
+
+        Assert.assertEquals(message.getEntity(), storedMessage.getEntity());
+        Assert.assertEquals(message.getMessage(), storedMessage.getMessage());
+        Assert.assertEquals(Util.ISOFormat(startMillis, true, "UTC"), storedMessage.getDate());
+    }
+    @Test
+    public void testLocalTimeUnsupported() throws Exception {
+        String entityName = "message-query-test-localtime";
+        Message message = new Message(entityName);
+        message.setMessage("hello");
+        message.setDate("2016-07-21T00:00:00Z");
+
+        Assert.assertTrue("Fail to insert message", insertMessage(message, 1000));
+
+        MessageQuery messageQuery = new MessageQuery();
+        messageQuery.setEntity(entityName);
+        messageQuery.setStartDate("2016-07-21 00:00:00");
+        messageQuery.setInterval(new Interval(1, IntervalUnit.SECOND));
+        Response response = executeQuery(messageQuery);
+
+        assertEquals(BAD_REQUEST.getStatusCode(), response.getStatus());
+        JSONAssert.assertEquals("{\"error\":\"IllegalArgumentException: Wrong startDate syntax: 2016-07-21 00:00:00\"}", response.readEntity(String.class), true);
+
+    }
+    @Test
+    public void testXXTimezoneUnsupported() throws Exception {
+        String entityName = "message-query-test-xx-timezone";
+        Message message = new Message(entityName);
+        message.setMessage("hello");
+        message.setDate("2016-07-21T00:00:00Z");
+
+        Assert.assertTrue("Fail to insert message", insertMessage(message, 1000));
+
+        MessageQuery messageQuery = new MessageQuery();
+        messageQuery.setEntity(entityName);
+        messageQuery.setStartDate("2016-07-20T22:50:00-0110");
+        messageQuery.setInterval(new Interval(1, IntervalUnit.SECOND));
+        Response response = executeQuery(messageQuery);
+
+        assertEquals(BAD_REQUEST.getStatusCode(), response.getStatus());
+        JSONAssert.assertEquals("{\"error\":\"IllegalArgumentException: Wrong startDate syntax: 2016-07-20T22:50:00-0110\"}", response.readEntity(String.class), true);
+    }
+    @Test
+    public void testMillisecondsUnsupported() throws Exception {
+        String entityName = "message-query-test-millis";
+        Message message = new Message(entityName);
+        message.setMessage("hello");
+        message.setDate("2016-07-21T00:00:00Z");
+
+        Assert.assertTrue("Fail to insert message", insertMessage(message, 1000));
+
+        MessageQuery messageQuery = new MessageQuery();
+        messageQuery.setEntity(entityName);
+        messageQuery.setStartDate("1469059200000");
+        messageQuery.setInterval(new Interval(1, IntervalUnit.SECOND));
+        Response response = executeQuery(messageQuery);
+
+        assertEquals(BAD_REQUEST.getStatusCode(), response.getStatus());
+        JSONAssert.assertEquals("{\"error\":\"IllegalArgumentException: Wrong startDate syntax: 1469059200000\"}", response.readEntity(String.class), true);
+    }
+
+}

--- a/src/test/java/com/axibase/tsd/api/method/message/MessageQueryTest.java
+++ b/src/test/java/com/axibase/tsd/api/method/message/MessageQueryTest.java
@@ -1,11 +1,11 @@
 package com.axibase.tsd.api.method.message;
 
-import com.axibase.tsd.api.Util;
 import com.axibase.tsd.api.model.Interval;
 import com.axibase.tsd.api.model.IntervalUnit;
 import com.axibase.tsd.api.model.message.Message;
 import com.axibase.tsd.api.model.message.MessageQuery;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
 
@@ -17,125 +17,102 @@ import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
 import static org.junit.Assert.assertEquals;
 
 public class MessageQueryTest extends MessageMethod {
+    private static final Message message;
+
+    static {
+        message = new Message("message-query-test-isoz");
+        message.setMessage("hello");
+        message.setDate("2016-05-21T00:00:00.000Z");
+    }
+    @Before
+    public void prepare() throws Exception {
+        Assert.assertTrue("Fail to insert message", insertMessage(message, 1000));
+    }
+
+
+    /* #2850 */
     @Test
     public void testISOTimezoneZ() throws Exception {
-        long startMillis = 1463788800000L;
+        MessageQuery messageQuery = buildMessageQuery();
+        messageQuery.setStartDate("2016-05-21T00:00:00Z");
 
-        Message message = new Message("message-query-test-isoz");
-        message.setMessage("hello");
-        message.setDate(Util.ISOFormat(startMillis, false, "UTC"));
-
-        Assert.assertTrue("Fail to insert message", insertMessage(message, 1000));
-
-        MessageQuery messageQuery = new MessageQuery();
-        messageQuery.setEntity("message-query-test-isoz");
-        messageQuery.setStartDate(Util.ISOFormat(startMillis, false, "UTC"));
-        messageQuery.setInterval(new Interval(1, IntervalUnit.SECOND));
         List<Message> storedMessageList = executeQuery(messageQuery).readEntity(new GenericType<List<Message>>(){});
         Message storedMessage = storedMessageList.get(0);
 
-        Assert.assertEquals(message.getEntity(), storedMessage.getEntity());
-        Assert.assertEquals(message.getMessage(), storedMessage.getMessage());
-        Assert.assertEquals(Util.ISOFormat(startMillis, true, "UTC"), storedMessage.getDate());
+        assertEquals(message.getEntity(), storedMessage.getEntity());
+        assertEquals(message.getMessage(), storedMessage.getMessage());
+        assertEquals(message.getDate(), storedMessage.getDate());
     }
 
+    /* #2850 */
     @Test
     public void testISOTimezonePlusHourMinute() throws Exception {
-        long startMillis = 1463788800000L;
+        MessageQuery messageQuery = buildMessageQuery();
+        messageQuery.setStartDate("2016-05-21T00:01:23+01:23");
 
-        Message message = new Message("message-query-test-iso+hm");
-        message.setMessage("hello");
-        message.setDate(Util.ISOFormat(startMillis, false, "UTC"));
-
-        Assert.assertTrue("Fail to insert message", insertMessage(message, 1000));
-
-        MessageQuery messageQuery = new MessageQuery();
-        messageQuery.setEntity("message-query-test-iso+hm");
-        messageQuery.setStartDate(Util.ISOFormat(startMillis, false, "GMT+01:23"));
-        messageQuery.setInterval(new Interval(1, IntervalUnit.SECOND));
         List<Message> storedMessageList = executeQuery(messageQuery).readEntity(new GenericType<List<Message>>(){});
         Message storedMessage = storedMessageList.get(0);
 
-        Assert.assertEquals(message.getEntity(), storedMessage.getEntity());
-        Assert.assertEquals(message.getMessage(), storedMessage.getMessage());
-        Assert.assertEquals(Util.ISOFormat(startMillis, true, "UTC"), storedMessage.getDate());
+        assertEquals(message.getEntity(), storedMessage.getEntity());
+        assertEquals(message.getMessage(), storedMessage.getMessage());
+        assertEquals(message.getDate(), storedMessage.getDate());
     }
 
+    /* #2850 */
     @Test
     public void testISOTimezoneMinusHourMinute() throws Exception {
-        long startMillis = 1463788800000L;
+        MessageQuery messageQuery = buildMessageQuery();
+        messageQuery.setStartDate("2016-05-20T22:37:23-01:23");
 
-        Message message = new Message("message-query-test-iso-hm");
-        message.setMessage("hello");
-        message.setDate(Util.ISOFormat(startMillis, false, "UTC"));
-
-        Assert.assertTrue("Fail to insert message", insertMessage(message, 1000));
-
-        MessageQuery messageQuery = new MessageQuery();
-        messageQuery.setEntity("message-query-test-iso-hm");
-        messageQuery.setStartDate(Util.ISOFormat(startMillis, false, "GMT-01:23"));
-        messageQuery.setInterval(new Interval(1, IntervalUnit.SECOND));
         List<Message> storedMessageList = executeQuery(messageQuery).readEntity(new GenericType<List<Message>>(){});
         Message storedMessage = storedMessageList.get(0);
 
-        Assert.assertEquals(message.getEntity(), storedMessage.getEntity());
-        Assert.assertEquals(message.getMessage(), storedMessage.getMessage());
-        Assert.assertEquals(Util.ISOFormat(startMillis, true, "UTC"), storedMessage.getDate());
+        assertEquals(message.getEntity(), storedMessage.getEntity());
+        assertEquals(message.getMessage(), storedMessage.getMessage());
+        assertEquals(message.getDate(), storedMessage.getDate());
     }
+
+    /* #2850 */
     @Test
     public void testLocalTimeUnsupported() throws Exception {
-        String entityName = "message-query-test-localtime";
-        Message message = new Message(entityName);
-        message.setMessage("hello");
-        message.setDate("2016-07-21T00:00:00Z");
-
-        Assert.assertTrue("Fail to insert message", insertMessage(message, 1000));
-
-        MessageQuery messageQuery = new MessageQuery();
-        messageQuery.setEntity(entityName);
+        MessageQuery messageQuery = buildMessageQuery();
         messageQuery.setStartDate("2016-07-21 00:00:00");
-        messageQuery.setInterval(new Interval(1, IntervalUnit.SECOND));
+
         Response response = executeQuery(messageQuery);
 
         assertEquals(BAD_REQUEST.getStatusCode(), response.getStatus());
         JSONAssert.assertEquals("{\"error\":\"IllegalArgumentException: Wrong startDate syntax: 2016-07-21 00:00:00\"}", response.readEntity(String.class), true);
 
     }
+
+    /* #2850 */
     @Test
     public void testXXTimezoneUnsupported() throws Exception {
-        String entityName = "message-query-test-xx-timezone";
-        Message message = new Message(entityName);
-        message.setMessage("hello");
-        message.setDate("2016-07-21T00:00:00Z");
-
-        Assert.assertTrue("Fail to insert message", insertMessage(message, 1000));
-
-        MessageQuery messageQuery = new MessageQuery();
-        messageQuery.setEntity(entityName);
+        MessageQuery messageQuery = buildMessageQuery();
         messageQuery.setStartDate("2016-07-20T22:50:00-0110");
-        messageQuery.setInterval(new Interval(1, IntervalUnit.SECOND));
+
         Response response = executeQuery(messageQuery);
 
         assertEquals(BAD_REQUEST.getStatusCode(), response.getStatus());
         JSONAssert.assertEquals("{\"error\":\"IllegalArgumentException: Wrong startDate syntax: 2016-07-20T22:50:00-0110\"}", response.readEntity(String.class), true);
     }
+
+    /* #2850 */
     @Test
     public void testMillisecondsUnsupported() throws Exception {
-        String entityName = "message-query-test-millis";
-        Message message = new Message(entityName);
-        message.setMessage("hello");
-        message.setDate("2016-07-21T00:00:00Z");
-
-        Assert.assertTrue("Fail to insert message", insertMessage(message, 1000));
-
-        MessageQuery messageQuery = new MessageQuery();
-        messageQuery.setEntity(entityName);
+        MessageQuery messageQuery = buildMessageQuery();
         messageQuery.setStartDate("1469059200000");
-        messageQuery.setInterval(new Interval(1, IntervalUnit.SECOND));
+
         Response response = executeQuery(messageQuery);
 
         assertEquals(BAD_REQUEST.getStatusCode(), response.getStatus());
         JSONAssert.assertEquals("{\"error\":\"IllegalArgumentException: Wrong startDate syntax: 1469059200000\"}", response.readEntity(String.class), true);
     }
 
+    private MessageQuery buildMessageQuery() {
+        MessageQuery messageQuery = new MessageQuery();
+        messageQuery.setEntity(message.getEntity());
+        messageQuery.setInterval(new Interval(1, IntervalUnit.MILLISECOND));
+        return messageQuery;
+    }
 }

--- a/src/test/java/com/axibase/tsd/api/method/message/MessageQueryTest.java
+++ b/src/test/java/com/axibase/tsd/api/method/message/MessageQueryTest.java
@@ -1,7 +1,7 @@
 package com.axibase.tsd.api.method.message;
 
 import com.axibase.tsd.api.model.Interval;
-import com.axibase.tsd.api.model.IntervalUnit;
+import com.axibase.tsd.api.model.TimeUnit;
 import com.axibase.tsd.api.model.message.Message;
 import com.axibase.tsd.api.model.message.MessageQuery;
 import org.junit.Assert;
@@ -39,9 +39,9 @@ public class MessageQueryTest extends MessageMethod {
         List<Message> storedMessageList = executeQuery(messageQuery).readEntity(new GenericType<List<Message>>(){});
         Message storedMessage = storedMessageList.get(0);
 
-        assertEquals(message.getEntity(), storedMessage.getEntity());
-        assertEquals(message.getMessage(), storedMessage.getMessage());
-        assertEquals(message.getDate(), storedMessage.getDate());
+        assertEquals("Incorrect message entity", message.getEntity(), storedMessage.getEntity());
+        assertEquals("Incorrect message text", message.getMessage(), storedMessage.getMessage());
+        assertEquals("Incorrect message date", message.getDate(), storedMessage.getDate());
     }
 
     /* #2850 */
@@ -53,9 +53,9 @@ public class MessageQueryTest extends MessageMethod {
         List<Message> storedMessageList = executeQuery(messageQuery).readEntity(new GenericType<List<Message>>(){});
         Message storedMessage = storedMessageList.get(0);
 
-        assertEquals(message.getEntity(), storedMessage.getEntity());
-        assertEquals(message.getMessage(), storedMessage.getMessage());
-        assertEquals(message.getDate(), storedMessage.getDate());
+        assertEquals("Incorrect message entity", message.getEntity(), storedMessage.getEntity());
+        assertEquals("Incorrect message text", message.getMessage(), storedMessage.getMessage());
+        assertEquals("Incorrect message date", message.getDate(), storedMessage.getDate());
     }
 
     /* #2850 */
@@ -67,9 +67,9 @@ public class MessageQueryTest extends MessageMethod {
         List<Message> storedMessageList = executeQuery(messageQuery).readEntity(new GenericType<List<Message>>(){});
         Message storedMessage = storedMessageList.get(0);
 
-        assertEquals(message.getEntity(), storedMessage.getEntity());
-        assertEquals(message.getMessage(), storedMessage.getMessage());
-        assertEquals(message.getDate(), storedMessage.getDate());
+        assertEquals("Incorrect message entity", message.getEntity(), storedMessage.getEntity());
+        assertEquals("Incorrect message text", message.getMessage(), storedMessage.getMessage());
+        assertEquals("Incorrect message date", message.getDate(), storedMessage.getDate());
     }
 
     /* #2850 */
@@ -80,7 +80,7 @@ public class MessageQueryTest extends MessageMethod {
 
         Response response = executeQuery(messageQuery);
 
-        assertEquals(BAD_REQUEST.getStatusCode(), response.getStatus());
+        assertEquals("Incorrect response status code", BAD_REQUEST.getStatusCode(), response.getStatus());
         JSONAssert.assertEquals("{\"error\":\"IllegalArgumentException: Wrong startDate syntax: 2016-07-21 00:00:00\"}", response.readEntity(String.class), true);
 
     }
@@ -93,7 +93,7 @@ public class MessageQueryTest extends MessageMethod {
 
         Response response = executeQuery(messageQuery);
 
-        assertEquals(BAD_REQUEST.getStatusCode(), response.getStatus());
+        assertEquals("Incorrect response status code", BAD_REQUEST.getStatusCode(), response.getStatus());
         JSONAssert.assertEquals("{\"error\":\"IllegalArgumentException: Wrong startDate syntax: 2016-07-20T22:50:00-0110\"}", response.readEntity(String.class), true);
     }
 
@@ -105,14 +105,14 @@ public class MessageQueryTest extends MessageMethod {
 
         Response response = executeQuery(messageQuery);
 
-        assertEquals(BAD_REQUEST.getStatusCode(), response.getStatus());
+        assertEquals("Incorrect response status code", BAD_REQUEST.getStatusCode(), response.getStatus());
         JSONAssert.assertEquals("{\"error\":\"IllegalArgumentException: Wrong startDate syntax: 1469059200000\"}", response.readEntity(String.class), true);
     }
 
     private MessageQuery buildMessageQuery() {
         MessageQuery messageQuery = new MessageQuery();
         messageQuery.setEntity(message.getEntity());
-        messageQuery.setInterval(new Interval(1, IntervalUnit.MILLISECOND));
+        messageQuery.setInterval(new Interval(1, TimeUnit.MILLISECOND));
         return messageQuery;
     }
 }

--- a/src/test/java/com/axibase/tsd/api/method/property/PropertyDeleteTest.java
+++ b/src/test/java/com/axibase/tsd/api/method/property/PropertyDeleteTest.java
@@ -324,8 +324,8 @@ public class PropertyDeleteTest extends PropertyMethod {
         queryObj.put("key", new HashMap<String, String>(property.getKey()) {{
             put("k2", "kv2");
         }});
-        queryObj.put("startDate", Util.getMinDate());
-        queryObj.put("endDate", Util.getMaxDate());
+        queryObj.put("startDate", Util.MIN_STORABLE_DATE);
+        queryObj.put("endDate", Util.MAX_QUERYABLE_DATE);
         queryObj.put("exactMatch", true);
 
         assertEquals("Fail to execute delete query", OK.getStatusCode(), deleteProperty(queryObj).getStatus());
@@ -345,8 +345,8 @@ public class PropertyDeleteTest extends PropertyMethod {
         queryObj.put("key", new HashMap<String, String>(property.getKey()) {{
             put("k2", "kv2");
         }});
-        queryObj.put("startDate", Util.getMinDate());
-        queryObj.put("endDate", Util.getMaxDate());
+        queryObj.put("startDate", Util.MIN_STORABLE_DATE);
+        queryObj.put("endDate", Util.MAX_QUERYABLE_DATE);
         queryObj.put("exactMatch", false);
 
         assertEquals("Fail to execute delete query", OK.getStatusCode(), deleteProperty(queryObj).getStatus());
@@ -365,8 +365,8 @@ public class PropertyDeleteTest extends PropertyMethod {
         queryObj.put("key", new HashMap<String, String>() {{
             put("k2", "kv2");
         }});
-        queryObj.put("startDate", Util.getMinDate());
-        queryObj.put("endDate", Util.getMaxDate());
+        queryObj.put("startDate", Util.MIN_STORABLE_DATE);
+        queryObj.put("endDate", Util.MAX_QUERYABLE_DATE);
         queryObj.put("exactMatch", true);
 
         assertEquals("Fail to execute delete query", OK.getStatusCode(), deleteProperty(queryObj).getStatus());
@@ -385,8 +385,8 @@ public class PropertyDeleteTest extends PropertyMethod {
         queryObj.put("key", new HashMap<String, String>() {{
             put("k2", "kv2");
         }});
-        queryObj.put("startDate", Util.getMinDate());
-        queryObj.put("endDate", Util.getMaxDate());
+        queryObj.put("startDate", Util.MIN_STORABLE_DATE);
+        queryObj.put("endDate", Util.MAX_QUERYABLE_DATE);
         queryObj.put("exactMatch", false);
 
         assertEquals("Fail to execute delete query", OK.getStatusCode(), deleteProperty(queryObj).getStatus());
@@ -406,8 +406,8 @@ public class PropertyDeleteTest extends PropertyMethod {
         queryObj.put("key", new HashMap<String, String>() {{
             put("k1", "kv2");
         }});
-        queryObj.put("startDate", Util.getMinDate());
-        queryObj.put("endDate", Util.getMaxDate());
+        queryObj.put("startDate", Util.MIN_STORABLE_DATE);
+        queryObj.put("endDate", Util.MAX_QUERYABLE_DATE);
         queryObj.put("exactMatch", true);
 
         assertEquals("Fail to execute delete query", OK.getStatusCode(), deleteProperty(queryObj).getStatus());
@@ -427,8 +427,8 @@ public class PropertyDeleteTest extends PropertyMethod {
         queryObj.put("key", new HashMap<String, String>() {{
             put("k1", "kv2");
         }});
-        queryObj.put("startDate", Util.getMinDate());
-        queryObj.put("endDate", Util.getMaxDate());
+        queryObj.put("startDate", Util.MIN_STORABLE_DATE);
+        queryObj.put("endDate", Util.MAX_QUERYABLE_DATE);
         queryObj.put("exactMatch", false);
 
         assertEquals("Fail to execute delete query", OK.getStatusCode(), deleteProperty(queryObj).getStatus());

--- a/src/test/java/com/axibase/tsd/api/method/property/PropertyInsertTest.java
+++ b/src/test/java/com/axibase/tsd/api/method/property/PropertyInsertTest.java
@@ -4,7 +4,7 @@ import com.axibase.tsd.api.Util;
 import com.axibase.tsd.api.model.DateFilter;
 import com.axibase.tsd.api.model.EntityFilter;
 import com.axibase.tsd.api.model.Interval;
-import com.axibase.tsd.api.model.IntervalUnit;
+import com.axibase.tsd.api.model.TimeUnit;
 import com.axibase.tsd.api.model.property.Property;
 import com.axibase.tsd.api.model.property.PropertyQuery;
 import org.junit.Assert;
@@ -267,7 +267,7 @@ public class PropertyInsertTest extends PropertyMethod {
         DateFilter dateFilter = new DateFilter();
         String date = "2016-07-21T00:00:00.000Z";
         dateFilter.setStartDate(date);
-        dateFilter.setInterval(new Interval(1, IntervalUnit.MILLISECOND));
+        dateFilter.setInterval(new Interval(1, TimeUnit.MILLISECOND));
 
         propertyQuery.setEntityFilter(entityFilter);
         propertyQuery.setDateFilter(dateFilter);
@@ -276,9 +276,9 @@ public class PropertyInsertTest extends PropertyMethod {
         List<Property> storedPropertyList = getProperty(propertyQuery).readEntity(new GenericType<List<Property>>() {});
         Property storedProperty = storedPropertyList.get(0);
 
-        Assert.assertEquals(property.getEntity(), storedProperty.getEntity());
-        Assert.assertEquals(property.getTags(), storedProperty.getTags());
-        Assert.assertEquals(date, storedProperty.getDate());
+        Assert.assertEquals("Incorrect property entity", property.getEntity(), storedProperty.getEntity());
+        Assert.assertEquals("Incorrect property tags", property.getTags(), storedProperty.getTags());
+        Assert.assertEquals("Incorrect property date", date, storedProperty.getDate());
     }
 
     /* #2850 */
@@ -297,7 +297,7 @@ public class PropertyInsertTest extends PropertyMethod {
         DateFilter dateFilter = new DateFilter();
         String date = "2016-07-21T00:00:00.000Z";
         dateFilter.setStartDate(date);
-        dateFilter.setInterval(new Interval(1, IntervalUnit.MILLISECOND));
+        dateFilter.setInterval(new Interval(1, TimeUnit.MILLISECOND));
 
         propertyQuery.setEntityFilter(entityFilter);
         propertyQuery.setDateFilter(dateFilter);
@@ -306,9 +306,9 @@ public class PropertyInsertTest extends PropertyMethod {
         List<Property> storedPropertyList = getProperty(propertyQuery).readEntity(new GenericType<List<Property>>() {});
         Property storedProperty = storedPropertyList.get(0);
 
-        Assert.assertEquals(property.getEntity(), storedProperty.getEntity());
-        Assert.assertEquals(property.getTags(), storedProperty.getTags());
-        Assert.assertEquals(date, storedProperty.getDate());
+        Assert.assertEquals("Incorrect property entity", property.getEntity(), storedProperty.getEntity());
+        Assert.assertEquals("Incorrect property tags", property.getTags(), storedProperty.getTags());
+        Assert.assertEquals("Incorrect property date", date, storedProperty.getDate());
     }
 
     /* #2850 */
@@ -327,7 +327,7 @@ public class PropertyInsertTest extends PropertyMethod {
         DateFilter dateFilter = new DateFilter();
         String date = "2016-07-21T00:00:00.000Z";
         dateFilter.setStartDate(date);
-        dateFilter.setInterval(new Interval(1, IntervalUnit.MILLISECOND));
+        dateFilter.setInterval(new Interval(1, TimeUnit.MILLISECOND));
 
         propertyQuery.setEntityFilter(entityFilter);
         propertyQuery.setDateFilter(dateFilter);
@@ -336,9 +336,9 @@ public class PropertyInsertTest extends PropertyMethod {
         List<Property> storedPropertyList = getProperty(propertyQuery).readEntity(new GenericType<List<Property>>() {});
         Property storedProperty = storedPropertyList.get(0);
 
-        Assert.assertEquals(property.getEntity(), storedProperty.getEntity());
-        Assert.assertEquals(property.getTags(), storedProperty.getTags());
-        Assert.assertEquals(date, storedProperty.getDate());
+        Assert.assertEquals("Incorrect property entity", property.getEntity(), storedProperty.getEntity());
+        Assert.assertEquals("Incorrect property tags", property.getTags(), storedProperty.getTags());
+        Assert.assertEquals("Incorrect property date", date, storedProperty.getDate());
     }
 
     /* #2850 */
@@ -353,7 +353,7 @@ public class PropertyInsertTest extends PropertyMethod {
 
         Response response = insertProperty(property);
 
-        assertEquals(BAD_REQUEST.getStatusCode(), response.getStatus());
+        assertEquals("Incorrect response status code", BAD_REQUEST.getStatusCode(), response.getStatus());
         JSONAssert.assertEquals("{\"error\":\"IllegalArgumentException: Invalid date format\"}", response.readEntity(String.class), true);
 
     }
@@ -370,7 +370,7 @@ public class PropertyInsertTest extends PropertyMethod {
 
         Response response = insertProperty(property);
 
-        assertEquals(BAD_REQUEST.getStatusCode(), response.getStatus());
+        assertEquals("Incorrect response status code", BAD_REQUEST.getStatusCode(), response.getStatus());
         JSONAssert.assertEquals("{\"error\":\"IllegalArgumentException: Invalid date format\"}", response.readEntity(String.class), true);
     }
 
@@ -386,7 +386,7 @@ public class PropertyInsertTest extends PropertyMethod {
 
         Response response = insertProperty(property);
 
-        assertEquals(BAD_REQUEST.getStatusCode(), response.getStatus());
+        assertEquals("Incorrect response status code", BAD_REQUEST.getStatusCode(), response.getStatus());
         JSONAssert.assertEquals("{\"error\":\"IllegalArgumentException: Invalid date format\"}", response.readEntity(String.class), true);
     }
 

--- a/src/test/java/com/axibase/tsd/api/method/property/PropertyInsertTest.java
+++ b/src/test/java/com/axibase/tsd/api/method/property/PropertyInsertTest.java
@@ -251,38 +251,23 @@ public class PropertyInsertTest extends PropertyMethod {
         assertTrue(propertyExist(resultProperty));
     }
 
+    /* #2850 */
     @Test
     public void testISOTimezoneZ() throws Exception {
-        insertWithTimezoneAndCheck("property-insert-test-isoz", "test1", "UTC");
-    }
-
-    @Test
-    public void testISOTimezonePlusHourMinute() throws Exception {
-        insertWithTimezoneAndCheck("property-insert-test-iso+hm", "test2", "GMT+01:23");
-    }
-
-    @Test
-    public void testISOTimezoneMinusHourMinute() throws Exception {
-        insertWithTimezoneAndCheck("property-insert-test-iso-hm", "test3", "GMT-01:23");
-    }
-
-    private void insertWithTimezoneAndCheck(String entityName, String type, String timezone) {
-        long startMillis = 1463788800000L;
-
-        Property property = new Property(type, entityName);
+        Property property = new Property("test1", "property-insert-test-isoz");
         property.addTag("test", "test");
-        property.setDate(Util.ISOFormat(startMillis, false, timezone));
-        property.setKey(new HashMap<String, String>());
+        property.setDate("2016-07-21T00:00:00Z");
 
         insertProperty(property);
 
         PropertyQuery propertyQuery = new PropertyQuery();
         EntityFilter entityFilter = new EntityFilter();
-        entityFilter.setEntity(entityName);
+        entityFilter.setEntity("property-insert-test-isoz");
 
         DateFilter dateFilter = new DateFilter();
-        dateFilter.setStartDate(Util.ISOFormat(startMillis, false, "UTC"));
-        dateFilter.setInterval(new Interval(1, IntervalUnit.SECOND));
+        String date = "2016-07-21T00:00:00.000Z";
+        dateFilter.setStartDate(date);
+        dateFilter.setInterval(new Interval(1, IntervalUnit.MILLISECOND));
 
         propertyQuery.setEntityFilter(entityFilter);
         propertyQuery.setDateFilter(dateFilter);
@@ -293,8 +278,70 @@ public class PropertyInsertTest extends PropertyMethod {
 
         Assert.assertEquals(property.getEntity(), storedProperty.getEntity());
         Assert.assertEquals(property.getTags(), storedProperty.getTags());
-        Assert.assertEquals(Util.ISOFormat(startMillis, true, "UTC"), storedProperty.getDate());
+        Assert.assertEquals(date, storedProperty.getDate());
     }
+
+    /* #2850 */
+    @Test
+    public void testISOTimezonePlusHourMinute() throws Exception {
+        Property property = new Property("test2", "property-insert-test-iso+hm");
+        property.addTag("test", "test");
+        property.setDate("2016-07-21T01:23:00+01:23");
+
+        insertProperty(property);
+
+        PropertyQuery propertyQuery = new PropertyQuery();
+        EntityFilter entityFilter = new EntityFilter();
+        entityFilter.setEntity("property-insert-test-iso+hm");
+
+        DateFilter dateFilter = new DateFilter();
+        String date = "2016-07-21T00:00:00.000Z";
+        dateFilter.setStartDate(date);
+        dateFilter.setInterval(new Interval(1, IntervalUnit.MILLISECOND));
+
+        propertyQuery.setEntityFilter(entityFilter);
+        propertyQuery.setDateFilter(dateFilter);
+        propertyQuery.setType(property.getType());
+
+        List<Property> storedPropertyList = getProperty(propertyQuery).readEntity(new GenericType<List<Property>>() {});
+        Property storedProperty = storedPropertyList.get(0);
+
+        Assert.assertEquals(property.getEntity(), storedProperty.getEntity());
+        Assert.assertEquals(property.getTags(), storedProperty.getTags());
+        Assert.assertEquals(date, storedProperty.getDate());
+    }
+
+    /* #2850 */
+    @Test
+    public void testISOTimezoneMinusHourMinute() throws Exception {
+        Property property = new Property("test3", "property-insert-test-iso-hm");
+        property.addTag("test", "test");
+        property.setDate("2016-07-20T22:37:00-01:23");
+
+        insertProperty(property);
+
+        PropertyQuery propertyQuery = new PropertyQuery();
+        EntityFilter entityFilter = new EntityFilter();
+        entityFilter.setEntity("property-insert-test-iso-hm");
+
+        DateFilter dateFilter = new DateFilter();
+        String date = "2016-07-21T00:00:00.000Z";
+        dateFilter.setStartDate(date);
+        dateFilter.setInterval(new Interval(1, IntervalUnit.MILLISECOND));
+
+        propertyQuery.setEntityFilter(entityFilter);
+        propertyQuery.setDateFilter(dateFilter);
+        propertyQuery.setType(property.getType());
+
+        List<Property> storedPropertyList = getProperty(propertyQuery).readEntity(new GenericType<List<Property>>() {});
+        Property storedProperty = storedPropertyList.get(0);
+
+        Assert.assertEquals(property.getEntity(), storedProperty.getEntity());
+        Assert.assertEquals(property.getTags(), storedProperty.getTags());
+        Assert.assertEquals(date, storedProperty.getDate());
+    }
+
+    /* #2850 */
     @Test
     public void testLocalTimeUnsupported() throws Exception {
         String entityName = "property-insert-test-localtime";
@@ -310,6 +357,8 @@ public class PropertyInsertTest extends PropertyMethod {
         JSONAssert.assertEquals("{\"error\":\"IllegalArgumentException: Invalid date format\"}", response.readEntity(String.class), true);
 
     }
+
+    /* #2850 */
     @Test
     public void testXXTimezoneUnsupported() throws Exception {
         String entityName = "property-insert-test-xx-timezone";
@@ -324,6 +373,8 @@ public class PropertyInsertTest extends PropertyMethod {
         assertEquals(BAD_REQUEST.getStatusCode(), response.getStatus());
         JSONAssert.assertEquals("{\"error\":\"IllegalArgumentException: Invalid date format\"}", response.readEntity(String.class), true);
     }
+
+    /* #2850 */
     @Test
     public void testMillisecondsUnsupported() throws Exception {
         String entityName = "property-insert-test-milliseconds";

--- a/src/test/java/com/axibase/tsd/api/method/property/PropertyMethod.java
+++ b/src/test/java/com/axibase/tsd/api/method/property/PropertyMethod.java
@@ -7,11 +7,13 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.ws.rs.client.Entity;
-import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.io.IOException;
 import java.lang.invoke.MethodHandles;
-import java.util.*;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 
 import static javax.ws.rs.core.Response.Status.OK;
 
@@ -86,8 +88,8 @@ class PropertyMethod extends BaseMethod {
         query.put("type", property.getType());
         query.put("key", property.getKey());
         if (null == property.getDate()) {
-            query.put("startDate", Util.getMinDate());
-            query.put("endDate", Util.getMaxDate());
+            query.put("startDate", Util.MIN_STORABLE_DATE);
+            query.put("endDate", Util.MAX_QUERYABLE_DATE);
         } else {
             query.put("startDate", property.getDate());
             query.put("interval", new HashMap<String, Object>() {{

--- a/src/test/java/com/axibase/tsd/api/method/property/PropertyQueryOffsetTest.java
+++ b/src/test/java/com/axibase/tsd/api/method/property/PropertyQueryOffsetTest.java
@@ -112,8 +112,8 @@ public class PropertyQueryOffsetTest extends PropertyMethod {
         Map<String, Object> queryObj = new HashMap<>();
         queryObj.put("type", propertyType);
         queryObj.put("entity", "*");
-        queryObj.put("startDate", Util.getMinDate());
-        queryObj.put("endDate", Util.getMaxDate());
+        queryObj.put("startDate", Util.MIN_STORABLE_DATE);
+        queryObj.put("endDate", Util.MAX_QUERYABLE_DATE);
         queryObj.put("offset", offset);
         return getProperty(queryObj);
     }

--- a/src/test/java/com/axibase/tsd/api/method/property/PropertyQueryOffsetTest.java
+++ b/src/test/java/com/axibase/tsd/api/method/property/PropertyQueryOffsetTest.java
@@ -9,7 +9,6 @@ import org.skyscreamer.jsonassert.JSONAssert;
 
 import javax.ws.rs.core.Response;
 import java.io.IOException;
-import java.text.ParseException;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
@@ -104,11 +103,7 @@ public class PropertyQueryOffsetTest extends PropertyMethod {
             property.addKey(key[i], key[i + 1]);
         }
         property.addTag("defaultname", "defaultval");
-        try {
-            property.setDate(date);
-        } catch (ParseException e) {
-            throw new IllegalArgumentException("Can not parse currentDate string");
-        }
+        property.setDate(date);
 
         return property;
     }

--- a/src/test/java/com/axibase/tsd/api/method/property/PropertyQueryTest.java
+++ b/src/test/java/com/axibase/tsd/api/method/property/PropertyQueryTest.java
@@ -3,20 +3,13 @@ package com.axibase.tsd.api.method.property;
 
 import com.axibase.tsd.api.Util;
 import com.axibase.tsd.api.method.entity.EntityMethod;
-import com.axibase.tsd.api.model.DateFilter;
-import com.axibase.tsd.api.model.EntityFilter;
-import com.axibase.tsd.api.model.Interval;
-import com.axibase.tsd.api.model.IntervalUnit;
 import com.axibase.tsd.api.model.entity.Entity;
 import com.axibase.tsd.api.model.property.Property;
-import com.axibase.tsd.api.model.property.PropertyQuery;
-import org.junit.Assert;
 import org.junit.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.ws.rs.core.GenericType;
 import javax.ws.rs.core.Response;
 import java.io.IOException;
 import java.lang.invoke.MethodHandles;
@@ -73,7 +66,7 @@ public class PropertyQueryTest extends PropertyMethod {
         Map<String, Object> queryObj = new HashMap<>();
         queryObj.put("type", property.getType());
         queryObj.put("entity", "*");
-        queryObj.put("startDate", Util.getMinDate());
+        queryObj.put("startDate", Util.MIN_STORABLE_DATE);
         queryObj.put("endDate", "now");
         queryObj.put("exactMatch", false);
 
@@ -99,7 +92,7 @@ public class PropertyQueryTest extends PropertyMethod {
         Map<String, Object> queryObj = new HashMap<>();
         queryObj.put("type", property.getType());
         queryObj.put("entity", "*");
-        queryObj.put("startDate", Util.getMinDate());
+        queryObj.put("startDate", Util.MIN_STORABLE_DATE);
         queryObj.put("endDate", "now");
         queryObj.put("exactMatch", true);
 
@@ -128,7 +121,7 @@ public class PropertyQueryTest extends PropertyMethod {
         queryObj.put("type", property.getType());
         queryObj.put("entity", "*");
         queryObj.put("key", property.getKey());
-        queryObj.put("startDate", Util.getMinDate());
+        queryObj.put("startDate", Util.MIN_STORABLE_DATE);
         queryObj.put("endDate", "now");
         queryObj.put("exactMatch", false);
 
@@ -156,7 +149,7 @@ public class PropertyQueryTest extends PropertyMethod {
         queryObj.put("type", property.getType());
         queryObj.put("entity", "*");
         queryObj.put("key", property.getKey());
-        queryObj.put("startDate", Util.getMinDate());
+        queryObj.put("startDate", Util.MIN_STORABLE_DATE);
         queryObj.put("endDate", "now");
         queryObj.put("exactMatch", true);
 
@@ -178,7 +171,7 @@ public class PropertyQueryTest extends PropertyMethod {
         Map<String, Object> queryObj = new HashMap<>();
         queryObj.put("type", property.getType());
         queryObj.put("entity", property.getEntity());
-        queryObj.put("startDate", Util.getMinDate());
+        queryObj.put("startDate", Util.MIN_STORABLE_DATE);
         queryObj.put("endDate", "now");
         queryObj.put("key", new HashMap<String, String>() {{
             put("misskey", "misskey_value");
@@ -200,7 +193,7 @@ public class PropertyQueryTest extends PropertyMethod {
         Map<String, Object> queryObj = new HashMap<>();
         queryObj.put("type", property.getType());
         queryObj.put("entity", property.getEntity());
-        queryObj.put("startDate", Util.getMinDate());
+        queryObj.put("startDate", Util.MIN_STORABLE_DATE);
         queryObj.put("endDate", "now");
         queryObj.put("key", new HashMap<String, String>() {{
             put("miss_key", "miss_key_value");
@@ -221,7 +214,7 @@ public class PropertyQueryTest extends PropertyMethod {
         Map<String, Object> queryObj = new HashMap<>();
         queryObj.put("type", property.getType());
         queryObj.put("entity", property.getEntity());
-        queryObj.put("startDate", Util.getMinDate());
+        queryObj.put("startDate", Util.MIN_STORABLE_DATE);
         queryObj.put("endDate", "now");
         queryObj.put("key", new HashMap<String, String>() {{
             put("k1", "kv1");
@@ -242,7 +235,7 @@ public class PropertyQueryTest extends PropertyMethod {
         Map<String, Object> queryObj = new HashMap<>();
         queryObj.put("type", property.getType());
         queryObj.put("entity", property.getEntity());
-        queryObj.put("startDate", Util.getMinDate());
+        queryObj.put("startDate", Util.MIN_STORABLE_DATE);
         queryObj.put("endDate", "now");
         queryObj.put("key", property.getKey());
         queryObj.put("exactMatch", false);
@@ -262,7 +255,7 @@ public class PropertyQueryTest extends PropertyMethod {
         Map<String, Object> queryObj = new HashMap<>();
         queryObj.put("type", property.getType());
         queryObj.put("entity", property.getEntity());
-        queryObj.put("startDate", Util.getMinDate());
+        queryObj.put("startDate", Util.MIN_STORABLE_DATE);
         queryObj.put("endDate", "now");
         queryObj.put("key", property.getKey());
         queryObj.put("exactMatch", true);
@@ -297,8 +290,8 @@ public class PropertyQueryTest extends PropertyMethod {
             add(property.getEntity());
             add(lastProperty.getEntity());
         }});
-        queryObj.put("startDate", Util.getMinDate());
-        queryObj.put("endDate", Util.getMaxDate());
+        queryObj.put("startDate", Util.MIN_STORABLE_DATE);
+        queryObj.put("endDate", Util.MAX_QUERYABLE_DATE);
 
         String expected = jacksonMapper.writeValueAsString(Arrays.asList(property, lastProperty));
 
@@ -323,8 +316,8 @@ public class PropertyQueryTest extends PropertyMethod {
         Map<String, Object> queryObj = new HashMap<>();
         queryObj.put("type", property.getType());
         queryObj.put("entity", property.getEntity());
-        queryObj.put("startDate", Util.getMinDate());
-        queryObj.put("endDate", Util.getMaxDate());
+        queryObj.put("startDate", Util.MIN_STORABLE_DATE);
+        queryObj.put("endDate", Util.MAX_QUERYABLE_DATE);
 
         String expected = jacksonMapper.writeValueAsString(Arrays.asList(property, lastProperty));
 
@@ -349,8 +342,8 @@ public class PropertyQueryTest extends PropertyMethod {
         Map<String, Object> queryObj = new HashMap<>();
         queryObj.put("type", property.getType());
         queryObj.put("entity", property.getEntity());
-        queryObj.put("startDate", Util.getMinDate());
-        queryObj.put("endDate", Util.getMaxDate());
+        queryObj.put("startDate", Util.MIN_STORABLE_DATE);
+        queryObj.put("endDate", Util.MAX_QUERYABLE_DATE);
         queryObj.put("last", false);
 
         String expected = jacksonMapper.writeValueAsString(Arrays.asList(property, lastProperty));
@@ -378,8 +371,8 @@ public class PropertyQueryTest extends PropertyMethod {
         Map<String, Object> queryObj = new HashMap<>();
         queryObj.put("type", property.getType());
         queryObj.put("entity", property.getEntity());
-        queryObj.put("startDate", Util.getMinDate());
-        queryObj.put("endDate", Util.getMaxDate());
+        queryObj.put("startDate", Util.MIN_STORABLE_DATE);
+        queryObj.put("endDate", Util.MAX_QUERYABLE_DATE);
         queryObj.put("last", true);
 
         String expected = jacksonMapper.writeValueAsString(Collections.singletonList(lastProperty));
@@ -412,8 +405,8 @@ public class PropertyQueryTest extends PropertyMethod {
         Map<String, Object> queryObj = new HashMap<>();
         queryObj.put("type", property.getType());
         queryObj.put("entity", property.getEntity());
-        queryObj.put("startDate", Util.getMinDate());
-        queryObj.put("endDate", Util.getMaxDate());
+        queryObj.put("startDate", Util.MIN_STORABLE_DATE);
+        queryObj.put("endDate", Util.MAX_QUERYABLE_DATE);
         queryObj.put("last", true);
 
         String expected = jacksonMapper.writeValueAsString(Arrays.asList(lastProperty, lastPropertySecond));
@@ -432,7 +425,7 @@ public class PropertyQueryTest extends PropertyMethod {
         queryObj.put("type", property.getType());
         queryObj.put("entity", property.getEntity());
         queryObj.put("key", property.getKey());
-        queryObj.put("startDate", Util.getMinDate());
+        queryObj.put("startDate", Util.MIN_STORABLE_DATE);
         queryObj.put("interval", new HashMap<String, Object>() {{
             put("count", 999);
             put("unit", "YEAR");
@@ -456,7 +449,7 @@ public class PropertyQueryTest extends PropertyMethod {
         queryObj.put("type", property.getType());
         queryObj.put("entity", property.getEntity());
         queryObj.put("startDate", property.getDate());
-        queryObj.put("endDate", Util.getMaxDate());
+        queryObj.put("endDate", Util.MAX_QUERYABLE_DATE);
 
         String expected = jacksonMapper.writeValueAsString(Collections.singletonList(property));
 
@@ -643,8 +636,8 @@ public class PropertyQueryTest extends PropertyMethod {
         queryObj.put("type", "$entity_tags");
         queryObj.put("entity", entity.getName());
         queryObj.put("key", tags);
-        queryObj.put("startDate", Util.getMinDate());
-        queryObj.put("endDate", Util.getMaxDate());
+        queryObj.put("startDate", Util.MIN_STORABLE_DATE);
+        queryObj.put("endDate", Util.MAX_QUERYABLE_DATE);
         queryObj.put("exactMatch", true);
 
 
@@ -672,8 +665,8 @@ public class PropertyQueryTest extends PropertyMethod {
         queryObj.put("key", new HashMap<String, String>() {{
             put("t1", "v1");
         }});
-        queryObj.put("startDate", Util.getMinDate());
-        queryObj.put("endDate", Util.getMaxDate());
+        queryObj.put("startDate", Util.MIN_STORABLE_DATE);
+        queryObj.put("endDate", Util.MAX_QUERYABLE_DATE);
         queryObj.put("exactMatch", false);
 
 
@@ -698,8 +691,8 @@ public class PropertyQueryTest extends PropertyMethod {
         Map<String, Object> queryObj = new HashMap<>();
         queryObj.put("type", "$entity_tags");
         queryObj.put("entity", entity.getName());
-        queryObj.put("startDate", Util.getMinDate());
-        queryObj.put("endDate", Util.getMaxDate());
+        queryObj.put("startDate", Util.MIN_STORABLE_DATE);
+        queryObj.put("endDate", Util.MAX_QUERYABLE_DATE);
         queryObj.put("exactMatch", false);
 
 
@@ -726,8 +719,8 @@ public class PropertyQueryTest extends PropertyMethod {
         Map<String, Object> queryObj = new HashMap<>();
         queryObj.put("type", "$entity_tags");
         queryObj.put("entity", entity.getName());
-        queryObj.put("startDate", Util.getMinDate());
-        queryObj.put("endDate", Util.getMaxDate());
+        queryObj.put("startDate", Util.MIN_STORABLE_DATE);
+        queryObj.put("endDate", Util.MAX_QUERYABLE_DATE);
         queryObj.put("exactMatch", false);
 
 
@@ -758,8 +751,8 @@ public class PropertyQueryTest extends PropertyMethod {
         queryObj.put("type", "$entity_tags");
         queryObj.put("entity", entity.getName());
         queryObj.put("keyTagExpression", "tags.t1 == 'v1'");
-        queryObj.put("startDate", Util.getMinDate());
-        queryObj.put("endDate", Util.getMaxDate());
+        queryObj.put("startDate", Util.MIN_STORABLE_DATE);
+        queryObj.put("endDate", Util.MAX_QUERYABLE_DATE);
 
 
         String expected = jacksonMapper.writeValueAsString(Collections.singletonList(property));
@@ -788,8 +781,8 @@ public class PropertyQueryTest extends PropertyMethod {
         queryObj.put("type", "$entity_tags");
         queryObj.put("entity", entity.getName());
         queryObj.put("keyTagExpression", "tags.t1 == 'v2'");
-        queryObj.put("startDate", Util.getMinDate());
-        queryObj.put("endDate", Util.getMaxDate());
+        queryObj.put("startDate", Util.MIN_STORABLE_DATE);
+        queryObj.put("endDate", Util.MAX_QUERYABLE_DATE);
 
         JSONAssert.assertEquals("[]", formatToJsonString(getProperty(queryObj)), false);
     }
@@ -817,8 +810,8 @@ public class PropertyQueryTest extends PropertyMethod {
         queryObj.put("type", entityTagType);
         queryObj.put("entity", "wck-*");
         queryObj.put("key", entity1.getTags());
-        queryObj.put("startDate", Util.getMinDate());
-        queryObj.put("endDate", Util.getMaxDate());
+        queryObj.put("startDate", Util.MIN_STORABLE_DATE);
+        queryObj.put("endDate", Util.MAX_QUERYABLE_DATE);
 
         JSONAssert.assertEquals("[]", formatToJsonString(getProperty(queryObj)), false);
     }
@@ -851,8 +844,8 @@ public class PropertyQueryTest extends PropertyMethod {
         queryObj.put("type", entityTagType);
         queryObj.put("entity", "wcke-*");
         queryObj.put("keyTagExpression", "keys.wc2t1 = 'wc2V1' OR tags.wc2t2 = 'wc2v2'");
-        queryObj.put("startDate", Util.getMinDate());
-        queryObj.put("endDate", Util.getMaxDate());
+        queryObj.put("startDate", Util.MIN_STORABLE_DATE);
+        queryObj.put("endDate", Util.MAX_QUERYABLE_DATE);
 
         String expected = jacksonMapper.writeValueAsString(Collections.singletonList(property3));
 
@@ -878,8 +871,8 @@ public class PropertyQueryTest extends PropertyMethod {
         queryObj.put("type", entityTagType);
         queryObj.put("entity", entity.getName());
         queryObj.put("keyTagExpression", "tags.t1 == 'tV1'");
-        queryObj.put("startDate", Util.getMinDate());
-        queryObj.put("endDate", Util.getMaxDate());
+        queryObj.put("startDate", Util.MIN_STORABLE_DATE);
+        queryObj.put("endDate", Util.MAX_QUERYABLE_DATE);
 
 
         JSONAssert.assertEquals("[]", formatToJsonString(getProperty(queryObj)),false);
@@ -902,8 +895,8 @@ public class PropertyQueryTest extends PropertyMethod {
         queryObj.put("type", entityTagType);
         queryObj.put("entity", entity.getName());
         queryObj.put("keyTagExpression", "tags.T1 == 'tv1'");
-        queryObj.put("startDate", Util.getMinDate());
-        queryObj.put("endDate", Util.getMaxDate());
+        queryObj.put("startDate", Util.MIN_STORABLE_DATE);
+        queryObj.put("endDate", Util.MAX_QUERYABLE_DATE);
 
 
         String expected = jacksonMapper.writeValueAsString(Collections.singletonList(property));
@@ -935,8 +928,8 @@ public class PropertyQueryTest extends PropertyMethod {
         queryObj.put("type", property.getType());
         queryObj.put("entity", property.getEntity());
         queryObj.put("keyTagExpression", "tags.t1 == 'tv1' OR keys.k3 == 'kv3'");
-        queryObj.put("startDate", Util.getMinDate());
-        queryObj.put("endDate", Util.getMaxDate());
+        queryObj.put("startDate", Util.MIN_STORABLE_DATE);
+        queryObj.put("endDate", Util.MAX_QUERYABLE_DATE);
 
 
         String expected = jacksonMapper.writeValueAsString(Arrays.asList(property, property2, property3));
@@ -964,8 +957,8 @@ public class PropertyQueryTest extends PropertyMethod {
         queryObj.put("type", property.getType());
         queryObj.put("entity", property.getEntity());
         queryObj.put("keyTagExpression", "tags.t1 == 'tv1' AND keys.k2 == 'kv2'");
-        queryObj.put("startDate", Util.getMinDate());
-        queryObj.put("endDate", Util.getMaxDate());
+        queryObj.put("startDate", Util.MIN_STORABLE_DATE);
+        queryObj.put("endDate", Util.MAX_QUERYABLE_DATE);
 
 
         String expected = jacksonMapper.writeValueAsString(Collections.singletonList(property2));
@@ -991,8 +984,8 @@ public class PropertyQueryTest extends PropertyMethod {
         queryObj.put("type", property.getType());
         queryObj.put("entity", property.getEntity());
         queryObj.put("keyTagExpression", "tags.t1 LIKE 'tv*'");
-        queryObj.put("startDate", Util.getMinDate());
-        queryObj.put("endDate", Util.getMaxDate());
+        queryObj.put("startDate", Util.MIN_STORABLE_DATE);
+        queryObj.put("endDate", Util.MAX_QUERYABLE_DATE);
 
 
         String expected = jacksonMapper.writeValueAsString(Collections.singletonList(property));
@@ -1019,8 +1012,8 @@ public class PropertyQueryTest extends PropertyMethod {
         queryObj.put("type", property.getType());
         queryObj.put("entity", property.getEntity());
         queryObj.put("keyTagExpression", "keys.k1 LIKE 'kv*'");
-        queryObj.put("startDate", Util.getMinDate());
-        queryObj.put("endDate", Util.getMaxDate());
+        queryObj.put("startDate", Util.MIN_STORABLE_DATE);
+        queryObj.put("endDate", Util.MAX_QUERYABLE_DATE);
 
 
         String expected = jacksonMapper.writeValueAsString(Collections.singletonList(property));
@@ -1047,8 +1040,8 @@ public class PropertyQueryTest extends PropertyMethod {
         queryObj.put("type", property.getType());
         queryObj.put("entity", property.getEntity());
         queryObj.put("keyTagExpression", "tags.t1 == keys.k1");
-        queryObj.put("startDate", Util.getMinDate());
-        queryObj.put("endDate", Util.getMaxDate());
+        queryObj.put("startDate", Util.MIN_STORABLE_DATE);
+        queryObj.put("endDate", Util.MAX_QUERYABLE_DATE);
 
 
         String expected = jacksonMapper.writeValueAsString(Collections.singletonList(property));
@@ -1075,8 +1068,8 @@ public class PropertyQueryTest extends PropertyMethod {
         queryObj.put("type", property.getType());
         queryObj.put("entity", property.getEntity());
         queryObj.put("keyTagExpression", "tags.t1 != keys.k1");
-        queryObj.put("startDate", Util.getMinDate());
-        queryObj.put("endDate", Util.getMaxDate());
+        queryObj.put("startDate", Util.MIN_STORABLE_DATE);
+        queryObj.put("endDate", Util.MAX_QUERYABLE_DATE);
 
 
         String expected = jacksonMapper.writeValueAsString(Collections.singletonList(property2));
@@ -1102,8 +1095,8 @@ public class PropertyQueryTest extends PropertyMethod {
         queryObj.put("type", property.getType());
         queryObj.put("entity", property.getEntity());
         queryObj.put("keyTagExpression", "keys.k2 == ''");
-        queryObj.put("startDate", Util.getMinDate());
-        queryObj.put("endDate", Util.getMaxDate());
+        queryObj.put("startDate", Util.MIN_STORABLE_DATE);
+        queryObj.put("endDate", Util.MAX_QUERYABLE_DATE);
 
 
         String expected = jacksonMapper.writeValueAsString(Collections.singletonList(property));
@@ -1129,8 +1122,8 @@ public class PropertyQueryTest extends PropertyMethod {
         queryObj.put("type", property.getType());
         queryObj.put("entity", property.getEntity());
         queryObj.put("keyTagExpression", "keys.k2 != ''");
-        queryObj.put("startDate", Util.getMinDate());
-        queryObj.put("endDate", Util.getMaxDate());
+        queryObj.put("startDate", Util.MIN_STORABLE_DATE);
+        queryObj.put("endDate", Util.MAX_QUERYABLE_DATE);
 
 
         String expected = jacksonMapper.writeValueAsString(Collections.singletonList(property2));
@@ -1156,8 +1149,8 @@ public class PropertyQueryTest extends PropertyMethod {
         queryObj.put("type", property.getType());
         queryObj.put("entity", property.getEntity());
         queryObj.put("keyTagExpression", "tags.t2 == ''");
-        queryObj.put("startDate", Util.getMinDate());
-        queryObj.put("endDate", Util.getMaxDate());
+        queryObj.put("startDate", Util.MIN_STORABLE_DATE);
+        queryObj.put("endDate", Util.MAX_QUERYABLE_DATE);
 
 
         String expected = jacksonMapper.writeValueAsString(Collections.singletonList(property));
@@ -1183,8 +1176,8 @@ public class PropertyQueryTest extends PropertyMethod {
         queryObj.put("type", property.getType());
         queryObj.put("entity", property.getEntity());
         queryObj.put("keyTagExpression", "tags.t2 != ''");
-        queryObj.put("startDate", Util.getMinDate());
-        queryObj.put("endDate", Util.getMaxDate());
+        queryObj.put("startDate", Util.MIN_STORABLE_DATE);
+        queryObj.put("endDate", Util.MAX_QUERYABLE_DATE);
 
 
         String expected = jacksonMapper.writeValueAsString(Collections.singletonList(property2));
@@ -1203,8 +1196,8 @@ public class PropertyQueryTest extends PropertyMethod {
         queryObj.put("type", property.getType());
         queryObj.put("entity", property.getEntity());
         queryObj.put("keyTagExpression", "lower(tags.t1) == 'tv1'");
-        queryObj.put("startDate", Util.getMinDate());
-        queryObj.put("endDate", Util.getMaxDate());
+        queryObj.put("startDate", Util.MIN_STORABLE_DATE);
+        queryObj.put("endDate", Util.MAX_QUERYABLE_DATE);
 
 
         String expected = jacksonMapper.writeValueAsString(Collections.singletonList(property));
@@ -1224,8 +1217,8 @@ public class PropertyQueryTest extends PropertyMethod {
         queryObj.put("type", property.getType());
         queryObj.put("entity", property.getEntity());
         queryObj.put("keyTagExpression", "lower(keys.k1) == 'kv1'");
-        queryObj.put("startDate", Util.getMinDate());
-        queryObj.put("endDate", Util.getMaxDate());
+        queryObj.put("startDate", Util.MIN_STORABLE_DATE);
+        queryObj.put("endDate", Util.MAX_QUERYABLE_DATE);
 
 
         String expected = jacksonMapper.writeValueAsString(Collections.singletonList(property));
@@ -1244,8 +1237,8 @@ public class PropertyQueryTest extends PropertyMethod {
         queryObj.put("type", property.getType());
         queryObj.put("entity", property.getEntity());
         queryObj.put("keyTagExpression", "upper(tags.t1) == 'TV1'");
-        queryObj.put("startDate", Util.getMinDate());
-        queryObj.put("endDate", Util.getMaxDate());
+        queryObj.put("startDate", Util.MIN_STORABLE_DATE);
+        queryObj.put("endDate", Util.MAX_QUERYABLE_DATE);
 
 
         String expected = jacksonMapper.writeValueAsString(Collections.singletonList(property));
@@ -1265,8 +1258,8 @@ public class PropertyQueryTest extends PropertyMethod {
         queryObj.put("type", property.getType());
         queryObj.put("entity", property.getEntity());
         queryObj.put("keyTagExpression", "upper(keys.k1) == 'KV1'");
-        queryObj.put("startDate", Util.getMinDate());
-        queryObj.put("endDate", Util.getMaxDate());
+        queryObj.put("startDate", Util.MIN_STORABLE_DATE);
+        queryObj.put("endDate", Util.MAX_QUERYABLE_DATE);
 
 
         String expected = jacksonMapper.writeValueAsString(Collections.singletonList(property));
@@ -1290,8 +1283,8 @@ public class PropertyQueryTest extends PropertyMethod {
         Map<String, Object> queryObj = new HashMap<>();
         queryObj.put("type", property.getType());
         queryObj.put("entity", property.getEntity());
-        queryObj.put("startDate", Util.getMinDate());
-        queryObj.put("endDate", Util.getMaxDate());
+        queryObj.put("startDate", Util.MIN_STORABLE_DATE);
+        queryObj.put("endDate", Util.MAX_QUERYABLE_DATE);
         queryObj.put("limit", 1);
 
         assertEquals(1, calculateJsonArraySize(formatToJsonString(getProperty(queryObj))));
@@ -1323,8 +1316,8 @@ public class PropertyQueryTest extends PropertyMethod {
         Map<String, Object> queryObj = new HashMap<>();
         queryObj.put("type", property.getType());
         queryObj.put("entity", property.getEntity());
-        queryObj.put("startDate", Util.getMinDate());
-        queryObj.put("endDate", Util.getMaxDate());
+        queryObj.put("startDate", Util.MIN_STORABLE_DATE);
+        queryObj.put("endDate", Util.MAX_QUERYABLE_DATE);
         queryObj.put("limit", 2);
 
         assertEquals(2, calculateJsonArraySize(formatToJsonString(getProperty(queryObj))));
@@ -1355,8 +1348,8 @@ public class PropertyQueryTest extends PropertyMethod {
         Map<String, Object> queryObj = new HashMap<>();
         queryObj.put("type", property.getType());
         queryObj.put("entity", property.getEntity());
-        queryObj.put("startDate", Util.getMinDate());
-        queryObj.put("endDate", Util.getMaxDate());
+        queryObj.put("startDate", Util.MIN_STORABLE_DATE);
+        queryObj.put("endDate", Util.MAX_QUERYABLE_DATE);
         queryObj.put("limit", 0);
 
         assertEquals(3, calculateJsonArraySize(formatToJsonString(getProperty(queryObj))));
@@ -1387,151 +1380,13 @@ public class PropertyQueryTest extends PropertyMethod {
         Map<String, Object> queryObj = new HashMap<>();
         queryObj.put("type", property.getType());
         queryObj.put("entity", property.getEntity());
-        queryObj.put("startDate", Util.getMinDate());
-        queryObj.put("endDate", Util.getMaxDate());
+        queryObj.put("startDate", Util.MIN_STORABLE_DATE);
+        queryObj.put("endDate", Util.MAX_QUERYABLE_DATE);
 
         queryObj.put("limit", -1);
         assertEquals(3, calculateJsonArraySize(formatToJsonString(getProperty(queryObj))));
 
         queryObj.put("limit", -5);
         assertEquals(3, calculateJsonArraySize(formatToJsonString(getProperty(queryObj))));
-    }
-
-    @Test
-    public void testISOTimezoneZ() throws Exception {
-        queryWithTimezoneAndCheck("property-query-test-isoz", "test-query1", "UTC");
-    }
-
-    @Test
-    public void testISOTimezonePlusHourMinute() throws Exception {
-        queryWithTimezoneAndCheck("property-query-test-iso+hm", "test-query2", "GMT+01:23");
-    }
-
-    @Test
-    public void testISOTimezoneMinusHourMinute() throws Exception {
-        queryWithTimezoneAndCheck("property-query-test-iso-hm", "test-query3", "GMT-01:23");
-    }
-
-    @Test
-    public void testLocalTimeUnsupported() throws Exception {
-        String entityName = "property-query-test-localtime";
-        String type = "test-query4";
-        Property property = new Property(type, entityName);
-        property.addTag("test", "test");
-        property.setDate("2016-07-21T00:00:00Z");
-
-        insertProperty(property);
-
-        PropertyQuery propertyQuery = new PropertyQuery();
-        propertyQuery.setType(type);
-
-        EntityFilter entityFilter = new EntityFilter();
-        entityFilter.setEntity(entityName);
-
-        propertyQuery.setEntityFilter(entityFilter);
-
-        DateFilter dateFilter = new DateFilter();
-        dateFilter.setStartDate("2016-07-21 00:00:00");
-        dateFilter.setInterval(new Interval(1, IntervalUnit.SECOND));
-
-        propertyQuery.setDateFilter(dateFilter);
-
-        Response response = getProperty(propertyQuery);
-
-        assertEquals(BAD_REQUEST.getStatusCode(), response.getStatus());
-        JSONAssert.assertEquals("{\"error\":\"IllegalArgumentException: Wrong startDate syntax: 2016-07-21 00:00:00\"}", response.readEntity(String.class), true);
-
-    }
-    @Test
-    public void testXXTimezoneUnsupported() throws Exception {
-        String entityName = "property-query-test-xx-timezone";
-        String type = "test-query5";
-        Property property = new Property(type, entityName);
-        property.addTag("test", "test");
-        property.setDate("2016-07-21T00:00:00Z");
-
-        insertProperty(property);
-
-        PropertyQuery propertyQuery = new PropertyQuery();
-        propertyQuery.setType(type);
-
-        EntityFilter entityFilter = new EntityFilter();
-        entityFilter.setEntity(entityName);
-
-        propertyQuery.setEntityFilter(entityFilter);
-
-        DateFilter dateFilter = new DateFilter();
-        dateFilter.setStartDate("2016-07-20T22:50:00-0110");
-        dateFilter.setInterval(new Interval(1, IntervalUnit.SECOND));
-
-        propertyQuery.setDateFilter(dateFilter);
-
-        Response response = getProperty(propertyQuery);
-
-        assertEquals(BAD_REQUEST.getStatusCode(), response.getStatus());
-        JSONAssert.assertEquals("{\"error\":\"IllegalArgumentException: Wrong startDate syntax: 2016-07-20T22:50:00-0110\"}", response.readEntity(String.class), true);
-    }
-    @Test
-    public void testMillisecondsUnsupported() throws Exception {
-        String entityName = "property-query-test-millis";
-        String type = "test-query6";
-        Property property = new Property(type, entityName);
-        property.addTag("test", "test");
-        property.setDate("2016-07-21T00:00:00Z");
-
-        insertProperty(property);
-
-        PropertyQuery propertyQuery = new PropertyQuery();
-        propertyQuery.setType(type);
-
-        EntityFilter entityFilter = new EntityFilter();
-        entityFilter.setEntity(entityName);
-
-        propertyQuery.setEntityFilter(entityFilter);
-
-        DateFilter dateFilter = new DateFilter();
-        dateFilter.setStartDate("1469059200000");
-        dateFilter.setInterval(new Interval(1, IntervalUnit.SECOND));
-
-        propertyQuery.setDateFilter(dateFilter);
-
-        Response response = getProperty(propertyQuery);
-
-        assertEquals(BAD_REQUEST.getStatusCode(), response.getStatus());
-        JSONAssert.assertEquals("{\"error\":\"IllegalArgumentException: Wrong startDate syntax: 1469059200000\"}", response.readEntity(String.class), true);
-    }
-
-
-
-    private void queryWithTimezoneAndCheck(String entityName, String type, String timezone) {
-        long startMillis = 1463788800000L;
-
-        Property property = new Property(type, entityName);
-        property.addTag("test", "test");
-        property.setDate(Util.ISOFormat(startMillis, false, "UTC"));
-        property.setKey(new HashMap<String, String>());
-
-        insertProperty(property);
-
-        PropertyQuery propertyQuery = new PropertyQuery();
-        propertyQuery.setType(type);
-
-        EntityFilter entityFilter = new EntityFilter();
-        entityFilter.setEntity(entityName);
-
-        DateFilter dateFilter = new DateFilter();
-        dateFilter.setStartDate(Util.ISOFormat(startMillis, false, timezone));
-        dateFilter.setInterval(new Interval(1, IntervalUnit.SECOND));
-
-        propertyQuery.setEntityFilter(entityFilter);
-        propertyQuery.setDateFilter(dateFilter);
-        propertyQuery.setType(property.getType());
-
-        List<Property> storedPropertyList = getProperty(propertyQuery).readEntity(new GenericType<List<Property>>() {});
-        Property storedProperty = storedPropertyList.get(0);
-
-        Assert.assertEquals(property.getEntity(), storedProperty.getEntity());
-        Assert.assertEquals(property.getTags(), storedProperty.getTags());
-        Assert.assertEquals(Util.ISOFormat(startMillis, true, "UTC"), storedProperty.getDate());
     }
 }

--- a/src/test/java/com/axibase/tsd/api/method/property/PropertyQueryTimezoneTest.java
+++ b/src/test/java/com/axibase/tsd/api/method/property/PropertyQueryTimezoneTest.java
@@ -3,7 +3,7 @@ package com.axibase.tsd.api.method.property;
 import com.axibase.tsd.api.model.DateFilter;
 import com.axibase.tsd.api.model.EntityFilter;
 import com.axibase.tsd.api.model.Interval;
-import com.axibase.tsd.api.model.IntervalUnit;
+import com.axibase.tsd.api.model.TimeUnit;
 import com.axibase.tsd.api.model.property.Property;
 import com.axibase.tsd.api.model.property.PropertyQuery;
 import org.junit.Before;
@@ -41,9 +41,9 @@ public class PropertyQueryTimezoneTest extends PropertyMethod {
         List<Property> storedPropertyList = getProperty(propertyQuery).readEntity(new GenericType<List<Property>>() {});
         Property storedProperty = storedPropertyList.get(0);
 
-        assertEquals(property.getEntity(), storedProperty.getEntity());
-        assertEquals(property.getTags(), storedProperty.getTags());
-        assertEquals(property.getDate(), storedProperty.getDate());
+        assertEquals("Incorrect property entity", property.getEntity(), storedProperty.getEntity());
+        assertEquals("Incorrect property tags", property.getTags(), storedProperty.getTags());
+        assertEquals("Incorrect property date", property.getDate(), storedProperty.getDate());
     }
 
     /* #2850 */
@@ -57,9 +57,9 @@ public class PropertyQueryTimezoneTest extends PropertyMethod {
         List<Property> storedPropertyList = getProperty(propertyQuery).readEntity(new GenericType<List<Property>>() {});
         Property storedProperty = storedPropertyList.get(0);
 
-        assertEquals(property.getEntity(), storedProperty.getEntity());
-        assertEquals(property.getTags(), storedProperty.getTags());
-        assertEquals(property.getDate(), storedProperty.getDate());
+        assertEquals("Incorrect property entity", property.getEntity(), storedProperty.getEntity());
+        assertEquals("Incorrect property tags", property.getTags(), storedProperty.getTags());
+        assertEquals("Incorrect property date", property.getDate(), storedProperty.getDate());
     }
 
     /* #2850 */
@@ -72,9 +72,9 @@ public class PropertyQueryTimezoneTest extends PropertyMethod {
         List<Property> storedPropertyList = getProperty(propertyQuery).readEntity(new GenericType<List<Property>>() {});
         Property storedProperty = storedPropertyList.get(0);
 
-        assertEquals(property.getEntity(), storedProperty.getEntity());
-        assertEquals(property.getTags(), storedProperty.getTags());
-        assertEquals(property.getDate(), storedProperty.getDate());
+        assertEquals("Incorrect property entity", property.getEntity(), storedProperty.getEntity());
+        assertEquals("Incorrect property tags", property.getTags(), storedProperty.getTags());
+        assertEquals("Incorrect property date", property.getDate(), storedProperty.getDate());
     }
 
     /* #2850 */
@@ -86,7 +86,7 @@ public class PropertyQueryTimezoneTest extends PropertyMethod {
 
         Response response = getProperty(propertyQuery);
 
-        assertEquals(BAD_REQUEST.getStatusCode(), response.getStatus());
+        assertEquals("Incorrect response status code", BAD_REQUEST.getStatusCode(), response.getStatus());
         JSONAssert.assertEquals("{\"error\":\"IllegalArgumentException: Wrong startDate syntax: 2016-07-21 00:00:00\"}", response.readEntity(String.class), true);
 
     }
@@ -100,7 +100,7 @@ public class PropertyQueryTimezoneTest extends PropertyMethod {
 
         Response response = getProperty(propertyQuery);
 
-        assertEquals(BAD_REQUEST.getStatusCode(), response.getStatus());
+        assertEquals("Incorrect response status code", BAD_REQUEST.getStatusCode(), response.getStatus());
         JSONAssert.assertEquals("{\"error\":\"IllegalArgumentException: Wrong startDate syntax: 2016-07-20T22:50:00-0110\"}", response.readEntity(String.class), true);
     }
 
@@ -113,7 +113,7 @@ public class PropertyQueryTimezoneTest extends PropertyMethod {
 
         Response response = getProperty(propertyQuery);
 
-        assertEquals(BAD_REQUEST.getStatusCode(), response.getStatus());
+        assertEquals("Incorrect response status code", BAD_REQUEST.getStatusCode(), response.getStatus());
         JSONAssert.assertEquals("{\"error\":\"IllegalArgumentException: Wrong startDate syntax: 1469059200000\"}", response.readEntity(String.class), true);
     }
 
@@ -126,7 +126,7 @@ public class PropertyQueryTimezoneTest extends PropertyMethod {
         entityFilter.setEntity(property.getEntity());
 
         DateFilter dateFilter = new DateFilter();
-        dateFilter.setInterval(new Interval(1, IntervalUnit.MILLISECOND));
+        dateFilter.setInterval(new Interval(1, TimeUnit.MILLISECOND));
 
         propertyQuery.setEntityFilter(entityFilter);
         propertyQuery.setDateFilter(dateFilter);

--- a/src/test/java/com/axibase/tsd/api/method/property/PropertyQueryTimezoneTest.java
+++ b/src/test/java/com/axibase/tsd/api/method/property/PropertyQueryTimezoneTest.java
@@ -1,0 +1,137 @@
+package com.axibase.tsd.api.method.property;
+
+import com.axibase.tsd.api.model.DateFilter;
+import com.axibase.tsd.api.model.EntityFilter;
+import com.axibase.tsd.api.model.Interval;
+import com.axibase.tsd.api.model.IntervalUnit;
+import com.axibase.tsd.api.model.property.Property;
+import com.axibase.tsd.api.model.property.PropertyQuery;
+import org.junit.Before;
+import org.junit.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
+
+import javax.ws.rs.core.GenericType;
+import javax.ws.rs.core.Response;
+import java.util.List;
+
+import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
+import static org.junit.Assert.assertEquals;
+
+public class PropertyQueryTimezoneTest extends PropertyMethod {
+    private static final Property property;
+
+    static {
+        property = new Property("property-query-test-isoz", "test-query1");
+        property.addTag("test", "test");
+        property.setDate("2016-05-21T00:00:00.000Z");
+    }
+    @Before
+    public void prepare() throws Exception {
+        insertProperty(property);
+    }
+
+    /* #2850 */
+    @Test
+    public void testISOTimezoneZ() throws Exception {
+
+        PropertyQuery propertyQuery = buildPropertyQuery();
+
+        propertyQuery.getDateFilter().setStartDate("2016-05-21T00:00:00Z");
+
+        List<Property> storedPropertyList = getProperty(propertyQuery).readEntity(new GenericType<List<Property>>() {});
+        Property storedProperty = storedPropertyList.get(0);
+
+        assertEquals(property.getEntity(), storedProperty.getEntity());
+        assertEquals(property.getTags(), storedProperty.getTags());
+        assertEquals(property.getDate(), storedProperty.getDate());
+    }
+
+    /* #2850 */
+    @Test
+    public void testISOTimezonePlusHourMinute() throws Exception {
+
+        PropertyQuery propertyQuery = buildPropertyQuery();
+
+        propertyQuery.getDateFilter().setStartDate("2016-05-21T01:23:00+01:23");
+
+        List<Property> storedPropertyList = getProperty(propertyQuery).readEntity(new GenericType<List<Property>>() {});
+        Property storedProperty = storedPropertyList.get(0);
+
+        assertEquals(property.getEntity(), storedProperty.getEntity());
+        assertEquals(property.getTags(), storedProperty.getTags());
+        assertEquals(property.getDate(), storedProperty.getDate());
+    }
+
+    /* #2850 */
+    @Test
+    public void testISOTimezoneMinusHourMinute() throws Exception {
+        PropertyQuery propertyQuery = buildPropertyQuery();
+
+        propertyQuery.getDateFilter().setStartDate("2016-05-20T22:37:00-01:23");
+
+        List<Property> storedPropertyList = getProperty(propertyQuery).readEntity(new GenericType<List<Property>>() {});
+        Property storedProperty = storedPropertyList.get(0);
+
+        assertEquals(property.getEntity(), storedProperty.getEntity());
+        assertEquals(property.getTags(), storedProperty.getTags());
+        assertEquals(property.getDate(), storedProperty.getDate());
+    }
+
+    /* #2850 */
+    @Test
+    public void testLocalTimeUnsupported() throws Exception {
+        PropertyQuery propertyQuery = buildPropertyQuery();
+
+        propertyQuery.getDateFilter().setStartDate("2016-07-21 00:00:00");
+
+        Response response = getProperty(propertyQuery);
+
+        assertEquals(BAD_REQUEST.getStatusCode(), response.getStatus());
+        JSONAssert.assertEquals("{\"error\":\"IllegalArgumentException: Wrong startDate syntax: 2016-07-21 00:00:00\"}", response.readEntity(String.class), true);
+
+    }
+
+    /* #2850 */
+    @Test
+    public void testXXTimezoneUnsupported() throws Exception {
+        PropertyQuery propertyQuery = buildPropertyQuery();
+
+        propertyQuery.getDateFilter().setStartDate("2016-07-20T22:50:00-0110");
+
+        Response response = getProperty(propertyQuery);
+
+        assertEquals(BAD_REQUEST.getStatusCode(), response.getStatus());
+        JSONAssert.assertEquals("{\"error\":\"IllegalArgumentException: Wrong startDate syntax: 2016-07-20T22:50:00-0110\"}", response.readEntity(String.class), true);
+    }
+
+    /* #2850 */
+    @Test
+    public void testMillisecondsUnsupported() throws Exception {
+        PropertyQuery propertyQuery = buildPropertyQuery();
+
+        propertyQuery.getDateFilter().setStartDate("1469059200000");
+
+        Response response = getProperty(propertyQuery);
+
+        assertEquals(BAD_REQUEST.getStatusCode(), response.getStatus());
+        JSONAssert.assertEquals("{\"error\":\"IllegalArgumentException: Wrong startDate syntax: 1469059200000\"}", response.readEntity(String.class), true);
+    }
+
+
+    private PropertyQuery buildPropertyQuery() {
+        PropertyQuery propertyQuery = new PropertyQuery();
+        propertyQuery.setType(property.getType());
+
+        EntityFilter entityFilter = new EntityFilter();
+        entityFilter.setEntity(property.getEntity());
+
+        DateFilter dateFilter = new DateFilter();
+        dateFilter.setInterval(new Interval(1, IntervalUnit.MILLISECOND));
+
+        propertyQuery.setEntityFilter(entityFilter);
+        propertyQuery.setDateFilter(dateFilter);
+
+        return propertyQuery;
+    }
+
+}

--- a/src/test/java/com/axibase/tsd/api/method/series/SeriesInsertTest.java
+++ b/src/test/java/com/axibase/tsd/api/method/series/SeriesInsertTest.java
@@ -15,10 +15,8 @@ import java.math.BigDecimal;
 import java.util.List;
 
 import static com.axibase.tsd.api.Util.*;
-import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
+import static javax.ws.rs.core.Response.Status.*;
 import static org.junit.Assert.*;
-import static javax.ws.rs.core.Response.Status.NOT_FOUND;
-import static javax.ws.rs.core.Response.Status.OK;
 
 
 public class SeriesInsertTest extends SeriesMethod {
@@ -514,7 +512,7 @@ public class SeriesInsertTest extends SeriesMethod {
 
         Response response = insertSeriesReturnResponse(series);
 
-        assertEquals(BAD_REQUEST.getStatusCode(), response.getStatus());
+        assertEquals("Incorrect response status code", BAD_REQUEST.getStatusCode(), response.getStatus());
         JSONAssert.assertEquals("{\"error\":\"org.codehaus.jackson.map.JsonMappingException: Expected 'T' character but found ' ' (through reference chain: com.axibase.tsd.model.api.ApiTimeSeriesModel[\\\"data\\\"]->com.axibase.tsd.model.api.ApiTimeSeriesValue[\\\"d\\\"])\"}", response.readEntity(String.class), true);
 
     }
@@ -531,7 +529,7 @@ public class SeriesInsertTest extends SeriesMethod {
 
         Response response = insertSeriesReturnResponse(series);
 
-        assertEquals(BAD_REQUEST.getStatusCode(), response.getStatus());
+        assertEquals("Incorrect response status code", BAD_REQUEST.getStatusCode(), response.getStatus());
         JSONAssert.assertEquals("{\"error\":\"org.codehaus.jackson.map.JsonMappingException: N/A (through reference chain: com.axibase.tsd.model.api.ApiTimeSeriesModel[\\\"data\\\"]->com.axibase.tsd.model.api.ApiTimeSeriesValue[\\\"d\\\"])\"}", response.readEntity(String.class), true);
     }
 
@@ -547,7 +545,7 @@ public class SeriesInsertTest extends SeriesMethod {
 
         Response response = insertSeriesReturnResponse(series);
 
-        assertEquals(BAD_REQUEST.getStatusCode(), response.getStatus());
+        assertEquals("Incorrect response status code", BAD_REQUEST.getStatusCode(), response.getStatus());
         JSONAssert.assertEquals("{\"error\":\"org.codehaus.jackson.map.JsonMappingException: Expected '-' character but found '5' (through reference chain: com.axibase.tsd.model.api.ApiTimeSeriesModel[\\\"data\\\"]->com.axibase.tsd.model.api.ApiTimeSeriesValue[\\\"d\\\"])\"}", response.readEntity(String.class), true);
     }
 

--- a/src/test/java/com/axibase/tsd/api/method/series/SeriesInsertTest.java
+++ b/src/test/java/com/axibase/tsd/api/method/series/SeriesInsertTest.java
@@ -502,6 +502,7 @@ public class SeriesInsertTest extends SeriesMethod {
         response.close();
     }
 
+    /* #2850 */
     @Test
     public void testLocalTimeUnsupported() throws Exception {
         String entityName = "e-iso-11";
@@ -517,6 +518,8 @@ public class SeriesInsertTest extends SeriesMethod {
         JSONAssert.assertEquals("{\"error\":\"org.codehaus.jackson.map.JsonMappingException: Expected 'T' character but found ' ' (through reference chain: com.axibase.tsd.model.api.ApiTimeSeriesModel[\\\"data\\\"]->com.axibase.tsd.model.api.ApiTimeSeriesValue[\\\"d\\\"])\"}", response.readEntity(String.class), true);
 
     }
+
+    /* #2850 */
     @Test
     public void testXXTimezoneUnsupported() throws Exception {
         String entityName = "e-iso-12";
@@ -531,6 +534,8 @@ public class SeriesInsertTest extends SeriesMethod {
         assertEquals(BAD_REQUEST.getStatusCode(), response.getStatus());
         JSONAssert.assertEquals("{\"error\":\"org.codehaus.jackson.map.JsonMappingException: N/A (through reference chain: com.axibase.tsd.model.api.ApiTimeSeriesModel[\\\"data\\\"]->com.axibase.tsd.model.api.ApiTimeSeriesValue[\\\"d\\\"])\"}", response.readEntity(String.class), true);
     }
+
+    /* #2850 */
     @Test
     public void testMillisecondsUnsupported() throws Exception {
         String entityName = "e-iso-13";

--- a/src/test/java/com/axibase/tsd/api/method/series/SeriesInsertTest.java
+++ b/src/test/java/com/axibase/tsd/api/method/series/SeriesInsertTest.java
@@ -8,15 +8,17 @@ import com.axibase.tsd.api.model.series.Sample;
 import com.axibase.tsd.api.model.series.Series;
 import com.axibase.tsd.api.model.series.SeriesQuery;
 import org.junit.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
 
 import javax.ws.rs.core.Response;
 import java.math.BigDecimal;
 import java.util.List;
 
 import static com.axibase.tsd.api.Util.*;
+import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
+import static org.junit.Assert.*;
 import static javax.ws.rs.core.Response.Status.NOT_FOUND;
 import static javax.ws.rs.core.Response.Status.OK;
-import static org.junit.Assert.*;
 
 
 public class SeriesInsertTest extends SeriesMethod {
@@ -270,6 +272,24 @@ public class SeriesInsertTest extends SeriesMethod {
         assertEquals("Stored date incorrect", d, seriesList.get(0).getData().get(0).getD());
         assertEquals("Stored value incorrect", new BigDecimal(value), seriesList.get(0).getData().get(0).getV());
     }
+    /* #2850 */
+    @Test
+    public void testISOFormatsMinusHoursNoMS() throws Exception {
+        String entityName = "e-iso-10";
+        String metricName = "m-iso-10";
+        String value = "0";
+
+        Series series = new Series(entityName, metricName);
+        String d = "2016-06-09T20:00:00.000Z";
+        series.addData(new Sample("2016-06-09T17:29:00-02:31", value));
+
+        assertTrue("Failed to insert series", insertSeries(series, 1000));
+
+        SeriesQuery seriesQuery = new SeriesQuery(series.getEntity(), series.getMetric(), d, "2016-06-09T20:00:01Z");
+        List<Series> seriesList = executeQueryReturnSeries(seriesQuery);
+        assertEquals("Stored date incorrect", d, seriesList.get(0).getData().get(0).getD());
+        assertEquals("Stored value incorrect", new BigDecimal(value), seriesList.get(0).getData().get(0).getV());
+    }
 
 
     /* #2913 */
@@ -481,4 +501,49 @@ public class SeriesInsertTest extends SeriesMethod {
         assertEquals("Nonexistent url with /api/v1 options doesn't return 200", OK.getStatusCode(), response.getStatus());
         response.close();
     }
+
+    @Test
+    public void testLocalTimeUnsupported() throws Exception {
+        String entityName = "e-iso-11";
+        String metricName = "m-iso-11";
+        String value = "0";
+
+        Series series = new Series(entityName, metricName);
+        series.addData(new Sample("2016-06-09 20:00:00", value));
+
+        Response response = insertSeriesReturnResponse(series);
+
+        assertEquals(BAD_REQUEST.getStatusCode(), response.getStatus());
+        JSONAssert.assertEquals("{\"error\":\"org.codehaus.jackson.map.JsonMappingException: Expected 'T' character but found ' ' (through reference chain: com.axibase.tsd.model.api.ApiTimeSeriesModel[\\\"data\\\"]->com.axibase.tsd.model.api.ApiTimeSeriesValue[\\\"d\\\"])\"}", response.readEntity(String.class), true);
+
+    }
+    @Test
+    public void testXXTimezoneUnsupported() throws Exception {
+        String entityName = "e-iso-12";
+        String metricName = "m-iso-12";
+        String value = "0";
+
+        Series series = new Series(entityName, metricName);
+        series.addData(new Sample("2016-06-09T09:50:00-1010", value));
+
+        Response response = insertSeriesReturnResponse(series);
+
+        assertEquals(BAD_REQUEST.getStatusCode(), response.getStatus());
+        JSONAssert.assertEquals("{\"error\":\"org.codehaus.jackson.map.JsonMappingException: N/A (through reference chain: com.axibase.tsd.model.api.ApiTimeSeriesModel[\\\"data\\\"]->com.axibase.tsd.model.api.ApiTimeSeriesValue[\\\"d\\\"])\"}", response.readEntity(String.class), true);
+    }
+    @Test
+    public void testMillisecondsUnsupported() throws Exception {
+        String entityName = "e-iso-13";
+        String metricName = "m-iso-13";
+        String value = "0";
+
+        Series series = new Series(entityName, metricName);
+        series.addData(new Sample("1465502400000", value));
+
+        Response response = insertSeriesReturnResponse(series);
+
+        assertEquals(BAD_REQUEST.getStatusCode(), response.getStatus());
+        JSONAssert.assertEquals("{\"error\":\"org.codehaus.jackson.map.JsonMappingException: Expected '-' character but found '5' (through reference chain: com.axibase.tsd.model.api.ApiTimeSeriesModel[\\\"data\\\"]->com.axibase.tsd.model.api.ApiTimeSeriesValue[\\\"d\\\"])\"}", response.readEntity(String.class), true);
+    }
+
 }

--- a/src/test/java/com/axibase/tsd/api/method/series/SeriesMethod.java
+++ b/src/test/java/com/axibase/tsd/api/method/series/SeriesMethod.java
@@ -36,7 +36,11 @@ public class SeriesMethod extends BaseMethod {
         }
         return OK.getStatusCode() == response.getStatus();
     }
-
+    public static Response insertSeriesReturnResponse(final Series series) {
+        Response response = httpApiResource.path(METHOD_SERIES_INSERT).request().post(Entity.entity(Collections.singletonList(series), MediaType.APPLICATION_JSON_TYPE));
+        response.bufferEntity();
+        return response;
+    }
     public static List<Series> executeQueryReturnSeries(final SeriesQuery seriesQuery) throws Exception {
         Response response = httpApiResource.path(METHOD_SERIES_QUERY).request().post(Entity.json(Collections.singletonList(seriesQuery)));
         if (OK.getStatusCode() == response.getStatus()) {
@@ -47,8 +51,12 @@ public class SeriesMethod extends BaseMethod {
         return response.readEntity(new GenericType<List<Series>>() {
         });
     }
-
-
+    public static Response executeQueryReturnResponse(final SeriesQuery seriesQuery) throws Exception {
+        Response response = httpApiResource.path(METHOD_SERIES_QUERY).request().post(Entity.entity(Collections.singletonList(seriesQuery), MediaType.APPLICATION_JSON_TYPE));
+        response.bufferEntity();
+        return response;
+    }
+    
     public static boolean insertSeries(final Series series) throws IOException, InterruptedException, JSONException {
         return insertSeries(series, 0);
     }

--- a/src/test/java/com/axibase/tsd/api/method/series/SeriesQueryTest.java
+++ b/src/test/java/com/axibase/tsd/api/method/series/SeriesQueryTest.java
@@ -1,0 +1,112 @@
+package com.axibase.tsd.api.method.series;
+
+import com.axibase.tsd.api.model.series.Sample;
+import com.axibase.tsd.api.model.series.Series;
+import com.axibase.tsd.api.model.series.SeriesQuery;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
+
+import javax.ws.rs.core.Response;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.List;
+import java.util.TimeZone;
+
+import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class SeriesQueryTest extends SeriesMethod {
+    private static final long sampleMillis = 1467383000000L;
+
+    @BeforeClass
+    public static void prepare() throws Exception {
+        Series series = new Series("series-query-e-1", "series-query-m-1");
+        series.addData(new Sample(sampleMillis, "1"));
+        boolean success = insertSeries(series);
+        assertTrue("Cannot store common dataset", success);
+        Thread.sleep(1000l);
+    }
+
+    @Test
+    public void testISOTimezoneZ() throws Exception {
+        SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
+        dateFormat.setTimeZone(TimeZone.getTimeZone("GMT+00:00"));
+
+        String startDate = dateFormat.format(new Date(sampleMillis));
+        String endDate = dateFormat.format(new Date(sampleMillis+1000));
+        SeriesQuery seriesQuery = new SeriesQuery("series-query-e-1", "series-query-m-1", startDate, endDate);
+        seriesQuery.setTimeFormat("milliseconds");
+        List<Series> storedSeries = executeQueryReturnSeries(seriesQuery);
+
+        assertEquals(sampleMillis, storedSeries.get(0).getData().get(0).getT().longValue());
+    }
+    @Test
+    public void testISOTimezonePlusHoursMinutes() throws Exception {
+        SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXXX");
+        dateFormat.setTimeZone(TimeZone.getTimeZone("GMT+01:23"));
+
+        String startDate = dateFormat.format(new Date(sampleMillis));
+        String endDate = dateFormat.format(new Date(sampleMillis+1000));
+        SeriesQuery seriesQuery = new SeriesQuery("series-query-e-1", "series-query-m-1", startDate, endDate);
+        seriesQuery.setTimeFormat("milliseconds");
+        List<Series> storedSeries = executeQueryReturnSeries(seriesQuery);
+
+        assertEquals(sampleMillis, storedSeries.get(0).getData().get(0).getT().longValue());
+    }
+    @Test
+    public void testISOTimezoneMinusHoursMinutes() throws Exception {
+        SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXXX");
+        dateFormat.setTimeZone(TimeZone.getTimeZone("GMT-01:23"));
+
+        String startDate = dateFormat.format(new Date(sampleMillis));
+        String endDate = dateFormat.format(new Date(sampleMillis+1000));
+        SeriesQuery seriesQuery = new SeriesQuery("series-query-e-1", "series-query-m-1", startDate, endDate);
+        seriesQuery.setTimeFormat("milliseconds");
+        List<Series> storedSeries = executeQueryReturnSeries(seriesQuery);
+
+        assertEquals(sampleMillis, storedSeries.get(0).getData().get(0).getT().longValue());
+    }
+
+
+    @Test
+    public void testLocalTimeUnsupported() throws Exception {
+        SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+        dateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+
+        String startDate = dateFormat.format(new Date(sampleMillis));
+        String endDate = dateFormat.format(new Date(sampleMillis+1000));
+        SeriesQuery seriesQuery = new SeriesQuery("series-query-e-4", "series-query-m-4", startDate, endDate);
+        Response response = executeQueryReturnResponse(seriesQuery);
+
+        assertEquals(BAD_REQUEST.getStatusCode(), response.getStatus());
+        JSONAssert.assertEquals("{\"error\":\"IllegalArgumentException: Wrong startDate syntax: 2016-07-01 14:23:20\"}", response.readEntity(String.class), true);
+
+    }
+    @Test
+    public void testXXTimezoneUnsupported() throws Exception {
+        SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXX");
+        dateFormat.setTimeZone(TimeZone.getTimeZone("GMT+01:23"));
+
+        String startDate = dateFormat.format(new Date(sampleMillis));
+        String endDate = dateFormat.format(new Date(sampleMillis+1000));
+        SeriesQuery seriesQuery = new SeriesQuery("series-query-e-5", "series-query-m-5", startDate, endDate);
+        Response response = executeQueryReturnResponse(seriesQuery);
+
+        assertEquals(BAD_REQUEST.getStatusCode(), response.getStatus());
+        JSONAssert.assertEquals("{\"error\":\"IllegalArgumentException: Wrong startDate syntax: 2016-07-01T15:46:20+0123\"}", response.readEntity(String.class), true);
+
+    }
+    @Test
+    public void testMillisecondsUnsupported() throws Exception {
+        String startDate = ""+sampleMillis;
+        String endDate = ""+(sampleMillis+1000);
+        SeriesQuery seriesQuery = new SeriesQuery("series-query-e-1", "series-query-m-1", startDate, endDate);
+        Response response = executeQueryReturnResponse(seriesQuery);
+
+        assertEquals(BAD_REQUEST.getStatusCode(), response.getStatus());
+        JSONAssert.assertEquals("{\"error\":\"IllegalArgumentException: Wrong startDate syntax: 1467383000000\"}", response.readEntity(String.class), true);
+    }
+
+}

--- a/src/test/java/com/axibase/tsd/api/method/series/SeriesQueryTest.java
+++ b/src/test/java/com/axibase/tsd/api/method/series/SeriesQueryTest.java
@@ -1,5 +1,7 @@
 package com.axibase.tsd.api.method.series;
 
+import com.axibase.tsd.api.model.Interval;
+import com.axibase.tsd.api.model.IntervalUnit;
 import com.axibase.tsd.api.model.series.Sample;
 import com.axibase.tsd.api.model.series.Series;
 import com.axibase.tsd.api.model.series.SeriesQuery;
@@ -8,105 +10,120 @@ import org.junit.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
 
 import javax.ws.rs.core.Response;
-import java.text.SimpleDateFormat;
-import java.util.Date;
 import java.util.List;
-import java.util.TimeZone;
 
 import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 public class SeriesQueryTest extends SeriesMethod {
-    private static final long sampleMillis = 1467383000000L;
+    private static final String sampleDate = "2016-07-01T14:23:20.000Z";
+    private static final Series series;
+
+    static {
+        series = new Series("series-query-e-1", "series-query-m-1");
+        series.addData(new Sample(sampleDate, "1"));
+    }
 
     @BeforeClass
     public static void prepare() throws Exception {
-        Series series = new Series("series-query-e-1", "series-query-m-1");
-        series.addData(new Sample(sampleMillis, "1"));
-        boolean success = insertSeries(series);
-        assertTrue("Cannot store common dataset", success);
+        boolean isSucceed = insertSeries(series);
+        assertTrue("Cannot store common dataset", isSucceed);
         Thread.sleep(1000l);
     }
 
+
+    /* #2850 */
     @Test
     public void testISOTimezoneZ() throws Exception {
-        SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
-        dateFormat.setTimeZone(TimeZone.getTimeZone("GMT+00:00"));
+        SeriesQuery seriesQuery = buildQuery();
 
-        String startDate = dateFormat.format(new Date(sampleMillis));
-        String endDate = dateFormat.format(new Date(sampleMillis+1000));
-        SeriesQuery seriesQuery = new SeriesQuery("series-query-e-1", "series-query-m-1", startDate, endDate);
-        seriesQuery.setTimeFormat("milliseconds");
+        seriesQuery.setStartDate("2016-07-01T14:23:20Z");
+
         List<Series> storedSeries = executeQueryReturnSeries(seriesQuery);
 
-        assertEquals(sampleMillis, storedSeries.get(0).getData().get(0).getT().longValue());
+        assertEquals(series.getEntity(), storedSeries.get(0).getEntity());
+        assertEquals(series.getMetric(), storedSeries.get(0).getMetric());
+        assertEquals(sampleDate, storedSeries.get(0).getData().get(0).getD());
     }
+
+    /* #2850 */
     @Test
     public void testISOTimezonePlusHoursMinutes() throws Exception {
-        SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXXX");
-        dateFormat.setTimeZone(TimeZone.getTimeZone("GMT+01:23"));
+        SeriesQuery seriesQuery = buildQuery();
 
-        String startDate = dateFormat.format(new Date(sampleMillis));
-        String endDate = dateFormat.format(new Date(sampleMillis+1000));
-        SeriesQuery seriesQuery = new SeriesQuery("series-query-e-1", "series-query-m-1", startDate, endDate);
-        seriesQuery.setTimeFormat("milliseconds");
+        seriesQuery.setStartDate("2016-07-01T15:46:20+01:23");
+
         List<Series> storedSeries = executeQueryReturnSeries(seriesQuery);
 
-        assertEquals(sampleMillis, storedSeries.get(0).getData().get(0).getT().longValue());
+        assertEquals(series.getEntity(), storedSeries.get(0).getEntity());
+        assertEquals(series.getMetric(), storedSeries.get(0).getMetric());
+        assertEquals(sampleDate, storedSeries.get(0).getData().get(0).getD());
     }
+
+    /* #2850 */
     @Test
     public void testISOTimezoneMinusHoursMinutes() throws Exception {
-        SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXXX");
-        dateFormat.setTimeZone(TimeZone.getTimeZone("GMT-01:23"));
+        SeriesQuery seriesQuery = buildQuery();
 
-        String startDate = dateFormat.format(new Date(sampleMillis));
-        String endDate = dateFormat.format(new Date(sampleMillis+1000));
-        SeriesQuery seriesQuery = new SeriesQuery("series-query-e-1", "series-query-m-1", startDate, endDate);
-        seriesQuery.setTimeFormat("milliseconds");
+        seriesQuery.setStartDate("2016-07-01T13:00:20-01:23");
+
         List<Series> storedSeries = executeQueryReturnSeries(seriesQuery);
 
-        assertEquals(sampleMillis, storedSeries.get(0).getData().get(0).getT().longValue());
+        assertEquals(series.getEntity(), storedSeries.get(0).getEntity());
+        assertEquals(series.getMetric(), storedSeries.get(0).getMetric());
+        assertEquals(sampleDate, storedSeries.get(0).getData().get(0).getD());
     }
 
 
+    /* #2850 */
     @Test
     public void testLocalTimeUnsupported() throws Exception {
-        SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
-        dateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+        SeriesQuery seriesQuery = buildQuery();
 
-        String startDate = dateFormat.format(new Date(sampleMillis));
-        String endDate = dateFormat.format(new Date(sampleMillis+1000));
-        SeriesQuery seriesQuery = new SeriesQuery("series-query-e-4", "series-query-m-4", startDate, endDate);
+        seriesQuery.setStartDate("2016-07-01 14:23:20");
+
         Response response = executeQueryReturnResponse(seriesQuery);
 
         assertEquals(BAD_REQUEST.getStatusCode(), response.getStatus());
         JSONAssert.assertEquals("{\"error\":\"IllegalArgumentException: Wrong startDate syntax: 2016-07-01 14:23:20\"}", response.readEntity(String.class), true);
 
     }
+
+    /* #2850 */
     @Test
     public void testXXTimezoneUnsupported() throws Exception {
-        SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXX");
-        dateFormat.setTimeZone(TimeZone.getTimeZone("GMT+01:23"));
+        SeriesQuery seriesQuery = buildQuery();
 
-        String startDate = dateFormat.format(new Date(sampleMillis));
-        String endDate = dateFormat.format(new Date(sampleMillis+1000));
-        SeriesQuery seriesQuery = new SeriesQuery("series-query-e-5", "series-query-m-5", startDate, endDate);
+        seriesQuery.setStartDate("2016-07-01T15:46:20+0123");
+
         Response response = executeQueryReturnResponse(seriesQuery);
 
         assertEquals(BAD_REQUEST.getStatusCode(), response.getStatus());
         JSONAssert.assertEquals("{\"error\":\"IllegalArgumentException: Wrong startDate syntax: 2016-07-01T15:46:20+0123\"}", response.readEntity(String.class), true);
 
     }
+
+    /* #2850 */
     @Test
     public void testMillisecondsUnsupported() throws Exception {
-        String startDate = ""+sampleMillis;
-        String endDate = ""+(sampleMillis+1000);
-        SeriesQuery seriesQuery = new SeriesQuery("series-query-e-1", "series-query-m-1", startDate, endDate);
+        SeriesQuery seriesQuery = buildQuery();
+
+        seriesQuery.setStartDate("1467383000000");
+
         Response response = executeQueryReturnResponse(seriesQuery);
 
         assertEquals(BAD_REQUEST.getStatusCode(), response.getStatus());
         JSONAssert.assertEquals("{\"error\":\"IllegalArgumentException: Wrong startDate syntax: 1467383000000\"}", response.readEntity(String.class), true);
     }
 
+
+    private SeriesQuery buildQuery() {
+        SeriesQuery seriesQuery = new SeriesQuery();
+        seriesQuery.setEntity("series-query-e-1");
+        seriesQuery.setMetric("series-query-m-1");
+
+        seriesQuery.setInterval(new Interval(1, IntervalUnit.MILLISECOND));
+        return seriesQuery;
+    }
 }

--- a/src/test/java/com/axibase/tsd/api/method/series/SeriesQueryTest.java
+++ b/src/test/java/com/axibase/tsd/api/method/series/SeriesQueryTest.java
@@ -1,7 +1,7 @@
 package com.axibase.tsd.api.method.series;
 
 import com.axibase.tsd.api.model.Interval;
-import com.axibase.tsd.api.model.IntervalUnit;
+import com.axibase.tsd.api.model.TimeUnit;
 import com.axibase.tsd.api.model.series.Sample;
 import com.axibase.tsd.api.model.series.Series;
 import com.axibase.tsd.api.model.series.SeriesQuery;
@@ -42,9 +42,9 @@ public class SeriesQueryTest extends SeriesMethod {
 
         List<Series> storedSeries = executeQueryReturnSeries(seriesQuery);
 
-        assertEquals(series.getEntity(), storedSeries.get(0).getEntity());
-        assertEquals(series.getMetric(), storedSeries.get(0).getMetric());
-        assertEquals(sampleDate, storedSeries.get(0).getData().get(0).getD());
+        assertEquals("Incorrect series entity", series.getEntity(), storedSeries.get(0).getEntity());
+        assertEquals("Incorrect series metric", series.getMetric(), storedSeries.get(0).getMetric());
+        assertEquals("Incorrect series sample date", sampleDate, storedSeries.get(0).getData().get(0).getD());
     }
 
     /* #2850 */
@@ -56,9 +56,9 @@ public class SeriesQueryTest extends SeriesMethod {
 
         List<Series> storedSeries = executeQueryReturnSeries(seriesQuery);
 
-        assertEquals(series.getEntity(), storedSeries.get(0).getEntity());
-        assertEquals(series.getMetric(), storedSeries.get(0).getMetric());
-        assertEquals(sampleDate, storedSeries.get(0).getData().get(0).getD());
+        assertEquals("Incorrect series entity", series.getEntity(), storedSeries.get(0).getEntity());
+        assertEquals("Incorrect series metric", series.getMetric(), storedSeries.get(0).getMetric());
+        assertEquals("Incorrect series sample date", sampleDate, storedSeries.get(0).getData().get(0).getD());
     }
 
     /* #2850 */
@@ -70,9 +70,9 @@ public class SeriesQueryTest extends SeriesMethod {
 
         List<Series> storedSeries = executeQueryReturnSeries(seriesQuery);
 
-        assertEquals(series.getEntity(), storedSeries.get(0).getEntity());
-        assertEquals(series.getMetric(), storedSeries.get(0).getMetric());
-        assertEquals(sampleDate, storedSeries.get(0).getData().get(0).getD());
+        assertEquals("Incorrect series entity", series.getEntity(), storedSeries.get(0).getEntity());
+        assertEquals("Incorrect series metric", series.getMetric(), storedSeries.get(0).getMetric());
+        assertEquals("Incorrect series sample date", sampleDate, storedSeries.get(0).getData().get(0).getD());
     }
 
 
@@ -85,7 +85,7 @@ public class SeriesQueryTest extends SeriesMethod {
 
         Response response = executeQueryReturnResponse(seriesQuery);
 
-        assertEquals(BAD_REQUEST.getStatusCode(), response.getStatus());
+        assertEquals("Incorrect response status code", BAD_REQUEST.getStatusCode(), response.getStatus());
         JSONAssert.assertEquals("{\"error\":\"IllegalArgumentException: Wrong startDate syntax: 2016-07-01 14:23:20\"}", response.readEntity(String.class), true);
 
     }
@@ -99,7 +99,7 @@ public class SeriesQueryTest extends SeriesMethod {
 
         Response response = executeQueryReturnResponse(seriesQuery);
 
-        assertEquals(BAD_REQUEST.getStatusCode(), response.getStatus());
+        assertEquals("Incorrect response status code", BAD_REQUEST.getStatusCode(), response.getStatus());
         JSONAssert.assertEquals("{\"error\":\"IllegalArgumentException: Wrong startDate syntax: 2016-07-01T15:46:20+0123\"}", response.readEntity(String.class), true);
 
     }
@@ -113,7 +113,7 @@ public class SeriesQueryTest extends SeriesMethod {
 
         Response response = executeQueryReturnResponse(seriesQuery);
 
-        assertEquals(BAD_REQUEST.getStatusCode(), response.getStatus());
+        assertEquals("Incorrect response status code", BAD_REQUEST.getStatusCode(), response.getStatus());
         JSONAssert.assertEquals("{\"error\":\"IllegalArgumentException: Wrong startDate syntax: 1467383000000\"}", response.readEntity(String.class), true);
     }
 
@@ -123,7 +123,7 @@ public class SeriesQueryTest extends SeriesMethod {
         seriesQuery.setEntity("series-query-e-1");
         seriesQuery.setMetric("series-query-m-1");
 
-        seriesQuery.setInterval(new Interval(1, IntervalUnit.MILLISECOND));
+        seriesQuery.setInterval(new Interval(1, TimeUnit.MILLISECOND));
         return seriesQuery;
     }
 }

--- a/src/test/java/com/axibase/tsd/api/model/DateFilter.java
+++ b/src/test/java/com/axibase/tsd/api/model/DateFilter.java
@@ -1,0 +1,38 @@
+package com.axibase.tsd.api.model;
+
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+/**
+ * @see <a href="https://github.com/axibase/atsd-docs/blob/master/api/data/filter-date.md#date-filter-fields">api docs</a>
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class DateFilter {
+    private String startDate;
+    private String endDate;
+    private Interval interval;
+
+    public String getStartDate() {
+        return startDate;
+    }
+
+    public void setStartDate(String startDate) {
+        this.startDate = startDate;
+    }
+
+    public String getEndDate() {
+        return endDate;
+    }
+
+    public void setEndDate(String endDate) {
+        this.endDate = endDate;
+    }
+
+    public Interval getInterval() {
+        return interval;
+    }
+
+    public void setInterval(Interval interval) {
+        this.interval = interval;
+    }
+}

--- a/src/test/java/com/axibase/tsd/api/model/EntityFilter.java
+++ b/src/test/java/com/axibase/tsd/api/model/EntityFilter.java
@@ -1,0 +1,48 @@
+package com.axibase.tsd.api.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import java.util.List;
+
+/**
+ * @see <a href="https://github.com/axibase/atsd-docs/blob/master/api/data/filter-entity.md#entity-filter-fields">api docs</a>
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class EntityFilter {
+    private String entity;
+    private List<String> entities;
+    private String entityGroup;
+    private String entityExpression;
+
+    public String getEntity() {
+        return entity;
+    }
+
+    public void setEntity(String entity) {
+        this.entity = entity;
+    }
+
+    public List<String> getEntities() {
+        return entities;
+    }
+
+    public void setEntities(List<String> entities) {
+        this.entities = entities;
+    }
+
+    public String getEntityGroup() {
+        return entityGroup;
+    }
+
+    public void setEntityGroup(String entityGroup) {
+        this.entityGroup = entityGroup;
+    }
+
+    public String getEntityExpression() {
+        return entityExpression;
+    }
+
+    public void setEntityExpression(String entityExpression) {
+        this.entityExpression = entityExpression;
+    }
+}

--- a/src/test/java/com/axibase/tsd/api/model/Interval.java
+++ b/src/test/java/com/axibase/tsd/api/model/Interval.java
@@ -2,9 +2,9 @@ package com.axibase.tsd.api.model;
 
 public class Interval {
     private int count;
-    private IntervalUnit unit;
+    private TimeUnit unit;
 
-    public Interval(int count, IntervalUnit unit) {
+    public Interval(int count, TimeUnit unit) {
         this.count = count;
         this.unit = unit;
     }
@@ -17,11 +17,11 @@ public class Interval {
         this.count = count;
     }
 
-    public IntervalUnit getUnit() {
+    public TimeUnit getUnit() {
         return unit;
     }
 
-    public void setUnit(IntervalUnit unit) {
+    public void setUnit(TimeUnit unit) {
         this.unit = unit;
     }
 }

--- a/src/test/java/com/axibase/tsd/api/model/Interval.java
+++ b/src/test/java/com/axibase/tsd/api/model/Interval.java
@@ -1,0 +1,27 @@
+package com.axibase.tsd.api.model;
+
+public class Interval {
+    private int count;
+    private IntervalUnit unit;
+
+    public Interval(int count, IntervalUnit unit) {
+        this.count = count;
+        this.unit = unit;
+    }
+
+    public int getCount() {
+        return count;
+    }
+
+    public void setCount(int count) {
+        this.count = count;
+    }
+
+    public IntervalUnit getUnit() {
+        return unit;
+    }
+
+    public void setUnit(IntervalUnit unit) {
+        this.unit = unit;
+    }
+}

--- a/src/test/java/com/axibase/tsd/api/model/IntervalUnit.java
+++ b/src/test/java/com/axibase/tsd/api/model/IntervalUnit.java
@@ -1,5 +1,0 @@
-package com.axibase.tsd.api.model;
-
-public enum IntervalUnit {
-    HOUR, MINUTE, SECOND, MILLISECOND
-}

--- a/src/test/java/com/axibase/tsd/api/model/IntervalUnit.java
+++ b/src/test/java/com/axibase/tsd/api/model/IntervalUnit.java
@@ -1,0 +1,5 @@
+package com.axibase.tsd.api.model;
+
+public enum IntervalUnit {
+    HOUR, MINUTE, SECOND
+}

--- a/src/test/java/com/axibase/tsd/api/model/IntervalUnit.java
+++ b/src/test/java/com/axibase/tsd/api/model/IntervalUnit.java
@@ -1,5 +1,5 @@
 package com.axibase.tsd.api.model;
 
 public enum IntervalUnit {
-    HOUR, MINUTE, SECOND
+    HOUR, MINUTE, SECOND, MILLISECOND
 }

--- a/src/test/java/com/axibase/tsd/api/model/ResultFilter.java
+++ b/src/test/java/com/axibase/tsd/api/model/ResultFilter.java
@@ -1,0 +1,40 @@
+package com.axibase.tsd.api.model;
+
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+/**
+ * @see <a href="https://github.com/axibase/atsd-docs/blob/master/api/data/properties/query.md#result-filter-fields">api docs</a>
+ */
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ResultFilter {
+    private Integer limit;
+    private Boolean last;
+    private Integer offset;
+
+    public Boolean isLast() {
+        return last;
+    }
+
+    public void setLast(Boolean last) {
+        this.last = last;
+    }
+
+    public Integer getOffset() {
+        return offset;
+    }
+
+    public void setOffset(Integer offset) {
+        this.offset = offset;
+    }
+
+
+    public Integer getLimit() {
+        return limit;
+    }
+
+    public void setLimit(Integer limit) {
+        this.limit = limit;
+    }
+}

--- a/src/test/java/com/axibase/tsd/api/model/TimeUnit.java
+++ b/src/test/java/com/axibase/tsd/api/model/TimeUnit.java
@@ -1,0 +1,14 @@
+package com.axibase.tsd.api.model;
+
+public enum TimeUnit {
+    NANOSECOND,
+    MILLISECOND,
+    SECOND,
+    MINUTE,
+    HOUR,
+    DAY,
+    WEEK,
+    MONTH,
+    QUARTER,
+    YEAR
+}

--- a/src/test/java/com/axibase/tsd/api/model/message/MessageQuery.java
+++ b/src/test/java/com/axibase/tsd/api/model/message/MessageQuery.java
@@ -1,5 +1,6 @@
 package com.axibase.tsd.api.model.message;
 
+import com.axibase.tsd.api.model.Interval;
 import com.fasterxml.jackson.annotation.JsonInclude;
 
 import java.util.Map;
@@ -14,12 +15,7 @@ public class MessageQuery {
     private String severity;
     private String source;
     private Map<String, String> tags;
-
-    public MessageQuery(String entity, String startDate, String endDate) {
-        this.entity = entity;
-        this.startDate = startDate;
-        this.endDate = endDate;
-    }
+    private Interval interval;
 
     public String getEntity() {
         return entity;
@@ -75,5 +71,13 @@ public class MessageQuery {
 
     public void setSource(String source) {
         this.source = source;
+    }
+
+    public Interval getInterval() {
+        return interval;
+    }
+
+    public void setInterval(Interval interval) {
+        this.interval = interval;
     }
 }

--- a/src/test/java/com/axibase/tsd/api/model/property/Property.java
+++ b/src/test/java/com/axibase/tsd/api/model/property/Property.java
@@ -3,8 +3,8 @@ package com.axibase.tsd.api.model.property;
 import com.axibase.tsd.api.Registry;
 import com.axibase.tsd.api.Util;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
-import java.text.ParseException;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
@@ -15,7 +15,7 @@ public class Property {
     private String entity;
     private Map<String, String> key;
     private Map<String, String> tags;
-    private Date date;
+    private String date;
 
     public Property() {
     }
@@ -82,22 +82,20 @@ public class Property {
     }
 
     public String getDate() {
-        if (date == null) {
-            return null;
-        }
-        return Util.ISOFormat(date);
+        return date;
     }
 
     public void setDate(Long millis) {
-        this.date = new Date(millis);
+        this.date = Util.ISOFormat(new Date(millis));
     }
 
     public void setDate(Date date) {
-        this.date = date;
+        this.date = Util.ISOFormat(date);
     }
 
-    public void setDate(String date) throws ParseException {
-        this.date = Util.parseDate(date);
+    @JsonProperty
+    public void setDate(String date) {
+        this.date = date;
     }
 
     @Override

--- a/src/test/java/com/axibase/tsd/api/model/property/PropertyQuery.java
+++ b/src/test/java/com/axibase/tsd/api/model/property/PropertyQuery.java
@@ -1,0 +1,83 @@
+package com.axibase.tsd.api.model.property;
+
+import com.axibase.tsd.api.model.DateFilter;
+import com.axibase.tsd.api.model.EntityFilter;
+import com.axibase.tsd.api.model.ResultFilter;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonUnwrapped;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class PropertyQuery {
+    private String type;
+    private Boolean exactMatch;
+    private String keyTagExpression;
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    private Map<String, String> key = new HashMap<>();
+
+    @JsonUnwrapped
+    private EntityFilter entityFilter;
+    @JsonUnwrapped
+    private DateFilter dateFilter;
+    @JsonUnwrapped
+    private ResultFilter resultFilter;
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public Boolean isExactMatch() {
+        return exactMatch;
+    }
+
+    public void setExactMatch(Boolean exactMatch) {
+        this.exactMatch = exactMatch;
+    }
+
+    public String getKeyTagExpression() {
+        return keyTagExpression;
+    }
+
+    public void setKeyTagExpression(String keyTagExpression) {
+        this.keyTagExpression = keyTagExpression;
+    }
+
+    public EntityFilter getEntityFilter() {
+        return entityFilter;
+    }
+
+    public void setEntityFilter(EntityFilter entityFilter) {
+        this.entityFilter = entityFilter;
+    }
+
+    public DateFilter getDateFilter() {
+        return dateFilter;
+    }
+
+    public void setDateFilter(DateFilter dateFilter) {
+        this.dateFilter = dateFilter;
+    }
+
+    public ResultFilter getResultFilter() {
+        return resultFilter;
+    }
+
+    public void setResultFilter(ResultFilter resultFilter) {
+        this.resultFilter = resultFilter;
+    }
+
+    public Map<String, String> getKey() {
+        return Collections.unmodifiableMap(key);
+    }
+
+    public void setKey(Map<String, String> key) {
+        this.key = new HashMap<>(key);
+    }
+}

--- a/src/test/java/com/axibase/tsd/api/model/series/SeriesQuery.java
+++ b/src/test/java/com/axibase/tsd/api/model/series/SeriesQuery.java
@@ -1,6 +1,7 @@
 package com.axibase.tsd.api.model.series;
 
 import com.axibase.tsd.api.Util;
+import com.axibase.tsd.api.model.Interval;
 import com.fasterxml.jackson.annotation.JsonInclude;
 
 import java.util.ArrayList;
@@ -13,6 +14,7 @@ public class SeriesQuery {
     private String metric;
     private String startDate;
     private String endDate;
+    private Interval interval;
     private Map<String, String> tags = new HashMap<>();
     private Map<String, Object> aggregate;
     private String timeFormat;
@@ -48,6 +50,7 @@ public class SeriesQuery {
         aggregate.put("period", period);
     }
 
+    public SeriesQuery() {}
     public SeriesQuery(String entity, String metric, long startTime, long endTime) {
         this.entity = entity;
         this.metric = metric;
@@ -127,5 +130,13 @@ public class SeriesQuery {
 
     public void setTimeFormat(String timeFormat) {
         this.timeFormat = timeFormat;
+    }
+
+    public Interval getInterval() {
+        return interval;
+    }
+
+    public void setInterval(Interval interval) {
+        this.interval = interval;
     }
 }

--- a/src/test/java/com/axibase/tsd/api/model/series/SeriesQuery.java
+++ b/src/test/java/com/axibase/tsd/api/model/series/SeriesQuery.java
@@ -15,6 +15,7 @@ public class SeriesQuery {
     private String endDate;
     private Map<String, String> tags = new HashMap<>();
     private Map<String, Object> aggregate;
+    private String timeFormat;
 
     public void addAggregateType(String type) {
         if (aggregate == null) {
@@ -118,5 +119,13 @@ public class SeriesQuery {
                 ", startDate='" + startDate + '\'' +
                 ", endDate='" + endDate + '\'' +
                 '}';
+    }
+
+    public String getTimeFormat() {
+        return timeFormat;
+    }
+
+    public void setTimeFormat(String timeFormat) {
+        this.timeFormat = timeFormat;
     }
 }


### PR DESCRIPTION
Add series/message/and property insert and query tests to atsd-api-tests project.

Insert records with specified formats:
1) yyyy-MM-dd'T'HH:mm:ss'Z'
2) yyyy-MM-dd'T'HH:mm:ss+hh:mm
3) yyyy-MM-dd'T'HH:mm:ss-hh:mm

Query with startDate and endDate specified in 3 different formats and check each time that returned record has the expected date (assertEquals millis).
Add test to verify that the following formats are not supported in insert and in query. assert is error:

yyyy-MM-dd'T'HH:mm:ss+hhmm
yyyy-MM-dd HH:mm:ss
milliseconds