### PR TITLE
SQL: Not equals operator new syntax tests

### DIFF
--- a/src/test/java/com/axibase/tsd/api/method/sql/operators/SqlNotEqualsOperator.java
+++ b/src/test/java/com/axibase/tsd/api/method/sql/operators/SqlNotEqualsOperator.java
@@ -1,0 +1,145 @@
+package com.axibase.tsd.api.method.sql.operators;
+
+import com.axibase.tsd.api.Util;
+import com.axibase.tsd.api.method.sql.SqlMethod;
+import com.axibase.tsd.api.model.series.Sample;
+import com.axibase.tsd.api.model.series.Series;
+import com.axibase.tsd.api.model.sql.StringTable;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author Igor Shmagrinskiy
+ */
+public class SqlNotEqualsOperator extends SqlMethod {
+    private static final String TEST_PREFIX = "sql-not-equals-syntax-";
+
+
+    @BeforeClass
+    public static void prepareData() {
+        Series series = new Series(TEST_PREFIX + "entity", TEST_PREFIX + "metric");
+        Sample sample1 = new Sample(Util.parseDate("2016-06-03T09:23:00.000Z").getTime(), "1.01");
+        series.setTags(Collections.unmodifiableMap(new HashMap<String, String>() {{
+            put("a", "b");
+        }}));
+        sendSamplesToSeries(series, sample1);
+    }
+
+    /**
+     * Following tests related to issue #2933
+     */
+
+
+    /**
+     * #2933
+     * Temporarily it throws an error. Related to issue #3038
+     */
+    @Test
+    public void testNotEqualsWithDatetimeIsFalse() {
+        final String sqlQuery = "" +
+                "SELECT entity, value, datetime FROM 'sql-not-equals-syntax-metric'" +
+                "WHERE datetime <> '2016-06-03T09:23:00.000Z' AND entity = 'sql-not-equals-syntax-entity'";
+
+        List<List<String>> resultRows = executeQuery(sqlQuery)
+                .readEntity(StringTable.class)
+                .filterRows("datetime");
+
+        assertTrue("Result rows must be empty", resultRows.isEmpty());
+    }
+
+    /**
+     * #2933
+     * Temporarily it throws an error. Related to issue #3038
+     */
+    @Test
+    public void testNotEqualsWithDatetimeIsTrue() {
+        final String sqlQuery = "" +
+                "SELECT entity, value, datetime FROM 'sql-not-equals-syntax-metric'" +
+                "WHERE datetime <> '2016-06-03T09:25:00.000Z' AND entity = 'sql-not-equals-syntax-entity'";
+        List<List<String>> expectedRows = Arrays.asList(
+                Arrays.asList("2016-06-03T09:23:00.000Z")
+        );
+
+        List<List<String>> resultRows = executeQuery(sqlQuery)
+                .readEntity(StringTable.class)
+                .filterRows("datetime");
+
+        assertEquals("Result rows must be indentical", expectedRows, resultRows);
+    }
+
+    /**
+     * issue #2933
+     */
+    @Test
+    public void testNotEqualsWithNumericIsFalse() {
+        final String sqlQuery = "" +
+                "SELECT entity, value FROM 'sql-not-equals-syntax-metric'" +
+                "WHERE value <> 1.2 AND entity = 'sql-not-equals-syntax-entity'";
+
+        List<List<String>> resultRows = executeQuery(sqlQuery)
+                .readEntity(StringTable.class)
+                .filterRows("value");
+
+        List<List<String>> expectedRows = Arrays.asList(
+                Arrays.asList("1.01")
+        );
+
+        assertEquals("Table value rows must be identical", expectedRows, resultRows);
+    }
+
+    /**
+     * issue #2933
+     */
+    @Test
+    public void testNotEqualsWithNumericIsTrue() {
+        final String sqlQuery = "" +
+                "SELECT entity, value FROM 'sql-not-equals-syntax-metric'" +
+                "WHERE value <> 1.01 AND entity = 'sql-not-equals-syntax-entity'";
+        List<List<String>> resultRows = executeQuery(sqlQuery)
+                .readEntity(StringTable.class)
+                .getRows();
+        assertTrue("Result rows must be empty", resultRows.isEmpty());
+    }
+
+    /**
+     * issue #2933
+     */
+    @Test
+    public void testNotEqualsWitStringIsFalse() {
+        final String sqlQuery = "" +
+                "SELECT entity, value, datetime FROM 'sql-not-equals-syntax-metric'" +
+                "WHERE tags.a <> 'b'";
+        List<List<String>> resultRows = executeQuery(sqlQuery)
+                .readEntity(StringTable.class)
+                .getRows();
+        assertTrue("Result rows must be empty", resultRows.isEmpty());
+    }
+
+    /**
+     * issue #2933
+     */
+    @Test
+    public void testNotEqualsWithStringIsTrue() {
+        final String sqlQuery = "" +
+                "SELECT entity, tags.a FROM 'sql-not-equals-syntax-metric'\n" +
+                "WHERE tags.a <> 'a' AND entity = 'sql-not-equals-syntax-entity'";
+
+        List<List<String>> resultRows = executeQuery(sqlQuery)
+                .readEntity(StringTable.class)
+                .filterRows("tags.a");
+
+        List<List<String>> expectedRows = Arrays.asList(
+                Arrays.asList("b")
+        );
+
+        assertEquals("Table value rows must be identical", expectedRows, resultRows);
+    }
+}

--- a/src/test/java/com/axibase/tsd/api/method/sql/operators/SqlNotEqualsOperator.java
+++ b/src/test/java/com/axibase/tsd/api/method/sql/operators/SqlNotEqualsOperator.java
@@ -8,6 +8,7 @@ import com.axibase.tsd.api.model.sql.StringTable;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import javax.ws.rs.ProcessingException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -39,40 +40,29 @@ public class SqlNotEqualsOperator extends SqlMethod {
 
 
     /**
-     * #2933
-     * Temporarily it throws an error. Related to issue #3038
+     * issue #2933
      */
-    @Test
+    @Test(expected = ProcessingException.class)
     public void testNotEqualsWithDatetimeIsFalse() {
         final String sqlQuery = "" +
                 "SELECT entity, value, datetime FROM 'sql-not-equals-syntax-metric'" +
                 "WHERE datetime <> '2016-06-03T09:23:00.000Z' AND entity = 'sql-not-equals-syntax-entity'";
 
-        List<List<String>> resultRows = executeQuery(sqlQuery)
-                .readEntity(StringTable.class)
-                .filterRows("datetime");
-
-        assertTrue("Result rows must be empty", resultRows.isEmpty());
+        executeQuery(sqlQuery)
+                .readEntity(StringTable.class);
     }
 
     /**
-     * #2933
-     * Temporarily it throws an error. Related to issue #3038
+     * issue #2933
      */
-    @Test
+    @Test(expected = ProcessingException.class)
     public void testNotEqualsWithDatetimeIsTrue() {
         final String sqlQuery = "" +
                 "SELECT entity, value, datetime FROM 'sql-not-equals-syntax-metric'" +
                 "WHERE datetime <> '2016-06-03T09:25:00.000Z' AND entity = 'sql-not-equals-syntax-entity'";
-        List<List<String>> expectedRows = Arrays.asList(
-                Arrays.asList("2016-06-03T09:23:00.000Z")
-        );
 
-        List<List<String>> resultRows = executeQuery(sqlQuery)
-                .readEntity(StringTable.class)
-                .filterRows("datetime");
-
-        assertEquals("Result rows must be indentical", expectedRows, resultRows);
+        executeQuery(sqlQuery)
+                .readEntity(StringTable.class);
     }
 
     /**

--- a/src/test/java/com/axibase/tsd/api/model/series/Series.java
+++ b/src/test/java/com/axibase/tsd/api/model/series/Series.java
@@ -53,6 +53,10 @@ public class Series {
         return tags;
     }
 
+    public void setTags(Map<String, String> tags) {
+        this.tags = tags;
+    }
+
     public List<Sample> getData() {
         return data;
     }

--- a/src/test/java/com/axibase/tsd/api/model/sql/StringTable.java
+++ b/src/test/java/com/axibase/tsd/api/model/sql/StringTable.java
@@ -6,9 +6,9 @@ import java.util.*;
 
 /**
  * @author Igor Shmagrinskiy
- *
- * Class for storing SQL result table in {@link String}
- * objects. It is using custom deserializer
+ *         <p>
+ *         Class for storing SQL result table in {@link String}
+ *         objects. It is using custom deserializer
  */
 @JsonDeserialize(using = StringTableDeserializer.class)
 public class StringTable {
@@ -115,5 +115,21 @@ public class StringTable {
             filteredRows.add(filteredRow);
         }
         return filteredRows;
+    }
+
+
+    /**
+     * Filter row values by column names. Leaves those values, that indexes corresponded
+     * with columnNames contained in the set of requested column names
+     *
+     * @param requestedColumnNames - set of requested column names represented as args
+     * @return filtered rows
+     */
+    public List<List<String>> filterRows(String... requestedColumnNames) {
+        Set<String> filter = new HashSet<>();
+        for (String columnName : requestedColumnNames) {
+            filter.add(columnName);
+        }
+        return filterRows(filter);
     }
 }


### PR DESCRIPTION
##  Not equals operator new syntax tests
- [x] Added tests for new operator `<>` that equals to `!=`
- [x] Added auxiliary methods:
   - `setTags` to Series class
  -  `filterRows` to StringTable class, that accepts args form arguments
 

