### PR TITLE
SQL: testing of documentation examples

### DIFF
--- a/src/test/java/com/axibase/tsd/api/method/sql/SqlTest.java
+++ b/src/test/java/com/axibase/tsd/api/method/sql/SqlTest.java
@@ -17,6 +17,11 @@ public class SqlTest extends SqlMethod {
         assertEquals("Table rows  must  be identical", row1, row2);
     }
 
+    public static void assertTableRows(List<List<String>> row1, StringTable table) {
+        List<List<String>> row2 = table.getRows();
+        assertEquals("Table rows  must  be identical", row1, row2);
+    }
+
     public void assertTableContainsColumnsValues(List<List<String>> values, StringTable table, String... columnNames) {
         assertEquals(String.format("Values of columns with names: %s are not equal to expected", columnNames), table.filterRows(columnNames), values);
     }

--- a/src/test/java/com/axibase/tsd/api/method/sql/examples/README.md
+++ b/src/test/java/com/axibase/tsd/api/method/sql/examples/README.md
@@ -1,0 +1,27 @@
+## Examples' tests
+
+| Document | Done |  Test | Passed |
+| --- | --- | --- | --- |
+| [alias.md](https://github.com/axibase/atsd-docs/blob/master/api/sql/examples/alias.md "alias.md") | Yes | [SqlAliasExampleTest](SqlAliasExampleTest.java) | Yes |
+| [all-tags.md](https://github.com/axibase/atsd-docs/blob/master/api/sql/examples/all-tags.md "all-tags.md") | Yes | [SqlAllTagsTest](SqlAllTagsExampleTest.java) | No |
+| [average-value.md](https://github.com/axibase/atsd-docs/blob/master/api/sql/examples/average-value.md "average-value.md") | Yes | [SqlAvgValueExampleTest](SqlAvgValueExampleTest.java)| Yes |
+| [counter-aggregator.md](https://github.com/axibase/atsd-docs/blob/master/api/sql/examples/counter-aggregator.md "counter-aggregator.md")  | Yes | [SqlCounterAggregatorExampleTest](SqlCounterAggregatorExampleTest.java) | Yes |
+| [datetime-format.md](https://github.com/axibase/atsd-docs/blob/master/api/sql/examples/datetime-format.md "datetime-format.md") | Yes | [SqlDateFormatExampleTest](SqlDateFormatExampleTest.java) | No |
+| [filter-by-tag.md](https://github.com/axibase/atsd-docs/blob/master/api/sql/examples/filter-by-tag.md "filter-by-tag.md") | Yes | [SqlFilterByTagExampleTest](SqlFilterByTagExampleTest.java) | No |
+| [filter-null-tag.md](https://github.com/axibase/atsd-docs/blob/master/api/sql/examples/filter-null-tag.md "filter-null-tag.md") | Yes | [SqlFilterNullTagExampleTest](SqlFilterNullTagExampleTest.java) | Yes |
+| [group-by-query-with-order-by.md](https://github.com/axibase/atsd-docs/blob/master/api/sql/examples/group-by-query-with-order-by.md "group-by-query-with-order-by.md") | Yes | [SqlGroupByWithOrderByExampleTest](SqlGroupByWithOrderByExampleTest.java) | Yes |
+| [group-having.md](https://github.com/axibase/atsd-docs/blob/master/api/sql/examples/group-having.md "group-having.md") | No | [SqlGroupHavingExampleTest](SqlGroupHavingExampleTest.java) | No |
+| [grouped-average.md](https://github.com/axibase/atsd-docs/blob/master/api/sql/examples/grouped-average.md "grouped-average.md") | No | [SqlGroupedAverageExampleTest](SqlGroupedAverageExampleTest.java) | No |
+| [grouped-having.md](https://github.com/axibase/atsd-docs/blob/master/api/sql/examples/grouped-having.md "grouped-having.md") | No | [SqlGroupedHavingExampleTest](SqlGroupedHavingExampleTest.java) | No |
+| [interpolate-edges.md](https://github.com/axibase/atsd-docs/blob/master/api/sql/examples/interpolate-edges.md "interpolate-edges.md") | No | [SqlInterpolateEdgesExampleTest](SqlInterpolateEdgesExampleTest.java) | No |
+| [interpolate.md](https://github.com/axibase/atsd-docs/blob/master/api/sql/examples/interpolate.md "interpolate.md") | No | [SqlInterpolateExampleTest](SqlInterpolateExampleTest.java) | No |
+| [join-derived-series.md](https://github.com/axibase/atsd-docs/blob/master/api/sql/examples/join-derived-series.md "join-derived-series.md") | No | [SqlJoinDerivedSeriesExampleTest](SqlJoinDerivedSeriesExampleTest.java) | No |
+| [join-using-entity.md](https://github.com/axibase/atsd-docs/blob/master/api/sql/examples/join-using-entity.md "join-using-entity.md") | No | [SqlJoinUsingEntityExampleTest](SqlJoinUsingEntityExampleTest.java) | No |
+| [join.md](https://github.com/axibase/atsd-docs/blob/master/api/sql/examples/join.md "join.md") | No | [SqlJoinExampleTest](SqlJoinExampleTest.java) | No |
+| [last-time.md](https://github.com/axibase/atsd-docs/blob/master/api/sql/examples/last-time.md "last-time.md") | No | [SqlLastTimeExampleTest](SqlLastTimeExampleTest.java) | No |
+| [max-value-time.md](https://github.com/axibase/atsd-docs/blob/master/api/sql/examples/max-value-time.md "max-value-time.md") | No | [SqlMaxValueTimeExampleTest](SqlMaxValueTimeExampleTest.java) | No |
+| [order-by-time.md](https://github.com/axibase/atsd-docs/blob/master/api/sql/examples/order-by-time.md "order-by-time.md") | No | [SqlOrderByTimeExampleTest](SqlOrderByTimeExampleTest.java) | No |
+| [outer-join-with-aggregation.md](https://github.com/axibase/atsd-docs/blob/master/api/sql/examples/outer-join-with-aggregation.md "outer-join-with-aggregation.md") | No | [SqlOuterJoinWithAggregationExampleTest](SqlOuterJoinWithAggregationExampleTest.java) | No |
+| [row-number.md](https://github.com/axibase/atsd-docs/blob/master/api/sql/examples/row-number.md "row-number.md") | No | [SqlRowNumberTopNTagsExampleTest](SqlRowNumberTopNTagsExampleTest.java) | No |
+| [select-all.md](https://github.com/axibase/atsd-docs/blob/master/api/sql/examples/select-all.md "select-all.md") | No | [SqlSelectAllExampleTest](SqlSelectAllExampleTest.java) | No |
+| [select-entity-tags-as-columns.md](https://github.com/axibase/atsd-docs/blob/master/api/sql/examples/select-entity-tags-as-columns.md "select-entity-tags-as-columns.md") | No | [SqlSelectEntityTagsAsColumnsExampleTest](SqlSelectEntityTagsAsColumnsExampleTest.java) | No |

--- a/src/test/java/com/axibase/tsd/api/method/sql/examples/SqlAliasExampleTest.java
+++ b/src/test/java/com/axibase/tsd/api/method/sql/examples/SqlAliasExampleTest.java
@@ -1,0 +1,50 @@
+package com.axibase.tsd.api.method.sql.examples;
+
+import com.axibase.tsd.api.method.sql.SqlTest;
+import com.axibase.tsd.api.model.series.Sample;
+import com.axibase.tsd.api.model.series.Series;
+import com.axibase.tsd.api.model.sql.StringTable;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * @author Igor Shmagrinskiy
+ */
+public class SqlAliasExampleTest extends SqlTest {
+    private static final String TEST_PREFIX = "sql-example-alias-";
+
+
+    @BeforeClass
+    public static void prepareData() {
+        sendSamplesToSeries(
+                new Series(TEST_PREFIX + "entity", TEST_PREFIX + "metric"),
+                new Sample("2016-06-17T19:16:00.000Z", "3.0")
+        );
+    }
+
+    /**
+     * Issue #3047
+     * Test for alias documentation example.
+     *
+     * @see <a href="Alias example">https://github.com/axibase/atsd-docs/blob/master/api/sql/examples/alias.md</a>
+     */
+    @Test
+    public void testAlias() {
+        String sqlQuery =
+                "SELECT datetime, value, entity, metric AS \"measurement\" \n" +
+                        "FROM 'sql-example-alias-metric' \n" +
+                        "WHERE entity = 'sql-example-alias-entity' \n" +
+                        "AND datetime >= '2016-06-17T19:15:00.000Z' AND datetime < '2016-06-17T19:17:00.000Z'";
+
+        StringTable resultTable = executeQuery(sqlQuery).readEntity(StringTable.class);
+
+        List<String> expectedColumnNames = Arrays.asList("datetime", "value", "entity", "measurement");
+
+        assertTableColumnsNames(expectedColumnNames, resultTable);
+    }
+
+
+}

--- a/src/test/java/com/axibase/tsd/api/method/sql/examples/SqlAllTagsExampleTest.java
+++ b/src/test/java/com/axibase/tsd/api/method/sql/examples/SqlAllTagsExampleTest.java
@@ -1,0 +1,83 @@
+package com.axibase.tsd.api.method.sql.examples;
+
+import com.axibase.tsd.api.method.sql.SqlTest;
+import com.axibase.tsd.api.model.series.Sample;
+import com.axibase.tsd.api.model.series.Series;
+import com.axibase.tsd.api.model.sql.StringTable;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+
+/**
+ * @author Igor Shmagrinskiy
+ */
+public class SqlAllTagsExampleTest extends SqlTest {
+    private final static String TEST_PREFIX = "sql-example-all-tags-";
+
+    @BeforeClass
+    public static void prepareData() {
+        Series series = new Series(TEST_PREFIX + "entity-1", TEST_PREFIX + "metric") {{
+            setTags(Collections.unmodifiableMap(new HashMap<String, String>() {{
+                put("tag1", "val1");
+            }}));
+        }};
+        sendSamplesToSeries(series, new Sample("2016-06-19T11:00:00.000Z", 1));
+        series.setEntity(TEST_PREFIX + "entity-2");
+        series.setTags(Collections.
+                unmodifiableMap(new HashMap<String, String>() {{
+                                    put("tag1", "val2");
+                                    put("tag2", "val2");
+                                }}
+                ));
+        sendSamplesToSeries(series, new Sample("2016-06-19T11:00:00.000Z", 2));
+        series.setEntity(TEST_PREFIX + "entity-3");
+        series.setTags(Collections.unmodifiableMap(new HashMap<String, String>() {
+            {
+                put("tag2", "val3");
+            }
+        }));
+        sendSamplesToSeries(series, new Sample("2016-06-19T11:00:00.000Z", 3));
+        series.setEntity(TEST_PREFIX + "entity-4");
+        series.setTags(Collections.unmodifiableMap(new HashMap<String, String>() {
+            {
+                put("tag4", "val4");
+            }
+        }));
+        sendSamplesToSeries(series, new Sample("2016-06-19T11:00:00.000Z", 4));
+    }
+
+    /**
+     * Issue #3047
+     * Test for query all tags documentation example.
+     *
+     * @see <a href="Query All Tags">https://github.com/axibase/atsd-docs/blob/master/api/sql/examples/all-tags.md</a>
+     */
+    @Test
+    public void testAllTagsExample() {
+
+
+        String sqlQuery =
+                "SELECT entity, datetime, value, tags.*\n" +
+                        "FROM 'sql-example-all-tags-metric'\n" +
+                        "WHERE datetime >= '2016-06-19T11:00:00.000Z' and datetime < '2016-06-19T12:00:00.000Z'";
+
+        StringTable resultTable = executeQuery(sqlQuery).readEntity(StringTable.class);
+
+        List<String> expectedColumnNames = Arrays.asList("entity", "datetime", "value", "tags.tag4", "tags.tag2", "tags.tag1");
+
+        assertTableColumnsNames(expectedColumnNames, resultTable);
+
+        List<List<String>> expectedRows = Arrays.asList(
+                Arrays.asList("sql-example-all-tags-entity-1", "2016-06-19T11:07:06.018Z", "1.0", "null", "null", "val1"),
+                Arrays.asList("sql-example-all-tags-entity-2", "2016-06-19T11:07:06.018Z2", "2.0", "null", "val2", "val2"),
+                Arrays.asList("sql-example-all-tags-entity-3", "2016-06-19T11:07:06.018Z2", "3.0", "null", "val3", "null"),
+                Arrays.asList("sql-example-all-tags-entity-4", "2016-06-19T11:07:06.018Z2", "4.0", "val4", "null", "null")
+        );
+
+        assertTableRows(expectedRows, resultTable);
+    }
+}

--- a/src/test/java/com/axibase/tsd/api/method/sql/examples/SqlAvgValueExampleTest.java
+++ b/src/test/java/com/axibase/tsd/api/method/sql/examples/SqlAvgValueExampleTest.java
@@ -1,0 +1,52 @@
+package com.axibase.tsd.api.method.sql.examples;
+
+import com.axibase.tsd.api.method.sql.SqlTest;
+import com.axibase.tsd.api.model.series.Sample;
+import com.axibase.tsd.api.model.series.Series;
+import com.axibase.tsd.api.model.sql.StringTable;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * @author Igor Shmagrinskiy
+ */
+public class SqlAvgValueExampleTest extends SqlTest {
+    private final static String TEST_PREFIX = "sql-example-avg-value-";
+
+    @BeforeClass
+    public static void prepareData() {
+        Series series = new Series(TEST_PREFIX + "entity", TEST_PREFIX + "metric");
+        sendSamplesToSeries(series,
+                new Sample("2016-06-19T11:00:00.000Z", "11.1"),
+                new Sample("2016-06-19T11:15:00.000Z", "11.5")
+
+        );
+    }
+
+    /**
+     * Issue #3047
+     * Test for query all tags documentation example.
+     *
+     * @see <a href="Average Value Query">https://github.com/axibase/atsd-docs/blob/master/api/sql/examples/average-value.md</a>
+     */
+    @Test
+    public void testAvgValueExample() {
+        String sqlQuery =
+                "SELECT entity, avg(value)\n" +
+                        "FROM 'sql-example-avg-value-metric' \n" +
+                        "WHERE entity = 'sql-example-avg-value-entity' " +
+                        "AND datetime >= '2016-06-19T11:00:00.000Z' AND datetime < '2016-06-19T11:16:00.000Z'";
+
+        StringTable resultTable = executeQuery(sqlQuery).readEntity(StringTable.class);
+
+        List<List<String>> expectedRows = Arrays.asList(
+                Arrays.asList("sql-example-avg-value-entity", "11.3")
+        );
+
+        assertTableRows(expectedRows, resultTable);
+
+    }
+}

--- a/src/test/java/com/axibase/tsd/api/method/sql/examples/SqlCounterAggregatorExampleTest.java
+++ b/src/test/java/com/axibase/tsd/api/method/sql/examples/SqlCounterAggregatorExampleTest.java
@@ -1,0 +1,123 @@
+package com.axibase.tsd.api.method.sql.examples;
+
+import com.axibase.tsd.api.method.sql.SqlTest;
+import com.axibase.tsd.api.model.series.Sample;
+import com.axibase.tsd.api.model.series.Series;
+import com.axibase.tsd.api.model.sql.StringTable;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * @author Igor Shmagrinskiy
+ */
+public class SqlCounterAggregatorExampleTest extends SqlTest {
+    private static final String TEST_PREFIX = "sql-example-counter-aggregator-";
+
+    @BeforeClass
+    public static void prepareData() {
+        Series series = new Series(TEST_PREFIX + "entity", TEST_PREFIX + "metric");
+        series.addTag("level", "ERROR");
+        sendSamplesToSeries(series,
+                new Sample("2016-06-19T11:00:00.000Z", "11.1"),
+                new Sample("2016-06-19T11:15:00.000Z", "11.5"),
+                new Sample("2015-09-30T09:00:05.869Z", "2.0"),
+                new Sample("2015-09-30T09:00:17.860Z", "3.0"),
+                new Sample("2015-09-30T09:00:28.195Z", "3.0"),
+                new Sample("2015-09-30T09:00:33.526Z", "3.0"),
+                new Sample("2015-09-30T09:00:38.858Z", "3.0"),
+                new Sample("2015-09-30T09:05:32.217Z", "3.0"),
+                new Sample("2015-09-30T09:06:00.211Z", "3.0"),
+                new Sample("2015-09-30T09:07:00.321Z", "3.0"),
+                new Sample("2015-09-30T09:08:00.353Z", "3.0"),
+                new Sample("2015-09-30T09:10:36.214Z", "3.0"),
+                new Sample("2015-09-30T09:11:36.503Z", "3.0"),
+                new Sample("2015-09-30T09:12:36.836Z", "3.0"),
+                new Sample("2015-09-30T09:13:36.901Z", "3.0"),
+                new Sample("2015-09-30T09:15:01.917Z", "2.0"),
+                new Sample("2015-09-30T09:15:30.948Z", "3.0"),
+                new Sample("2015-09-30T09:15:36.279Z", "3.0"),
+                new Sample("2015-09-30T09:16:36.369Z", "3.0"),
+                new Sample("2015-09-30T09:17:36.454Z", "3.0"),
+                new Sample("2015-09-30T09:19:36.559Z", "5.0"),
+                new Sample("2015-09-30T09:20:05.540Z", "7.0"),
+                new Sample("2015-09-30T09:20:10.547Z", "8.0"),
+                new Sample("2015-09-30T09:20:15.565Z", "8.0"),
+                new Sample("2015-09-30T09:20:20.571Z", "8.0"),
+                new Sample("2015-09-30T09:20:25.578Z", "8.0"),
+                new Sample("2015-09-30T09:25:32.833Z", "3.0"),
+                new Sample("2015-09-30T09:26:03.818Z", "3.0"),
+                new Sample("2015-09-30T09:27:04.143Z", "3.0"),
+                new Sample("2015-09-30T09:28:04.438Z", "3.0"),
+                new Sample("2015-09-30T09:30:13.153Z", "3.0"),
+                new Sample("2015-09-30T09:30:34.830Z", "3.0"),
+                new Sample("2015-09-30T09:31:34.965Z", "3.0"),
+                new Sample("2015-09-30T09:32:35.065Z", "3.0"),
+                new Sample("2015-09-30T09:35:32.089Z", "3.0"),
+                new Sample("2015-09-30T09:36:00.095Z", "3.0"),
+                new Sample("2015-09-30T09:37:00.125Z", "3.0"),
+                new Sample("2015-09-30T09:38:00.437Z", "3.0"),
+                new Sample("2015-09-30T09:40:06.418Z", "3.0"),
+                new Sample("2015-09-30T09:40:11.748Z", "3.0"),
+                new Sample("2015-09-30T09:40:16.778Z", "3.0"),
+                new Sample("2015-09-30T09:40:22.108Z", "3.0"),
+                new Sample("2015-09-30T09:43:35.007Z", "93.0"),
+                new Sample("2015-09-30T09:43:40.023Z", "453.0"),
+                new Sample("2015-09-30T09:43:45.044Z", "903.0"),
+                new Sample("2015-09-30T09:43:50.375Z", "1399.0"),
+                new Sample("2015-09-30T09:43:55.707Z", "1803.0"),
+                new Sample("2015-09-30T09:44:55.744Z", "1803.0"),
+                new Sample("2015-09-30T09:45:01.407Z", "1803.0"),
+                new Sample("2015-09-30T09:45:06.740Z", "1806.0"),
+                new Sample("2015-09-30T09:45:34.740Z", "1806.0"),
+                new Sample("2015-09-30T09:46:35.064Z", "1806.0"),
+                new Sample("2015-09-30T09:47:35.398Z", "1806.0"),
+                new Sample("2015-09-30T09:50:33.322Z", "3.0"),
+                new Sample("2015-09-30T09:51:03.995Z", "3.0"),
+                new Sample("2015-09-30T09:52:04.000Z", "3.0"),
+                new Sample("2015-09-30T09:53:04.009Z", "3.0"),
+                new Sample("2015-09-30T09:55:04.351Z", "2.0"),
+                new Sample("2015-09-30T09:55:34.683Z", "3.0"),
+                new Sample("2015-09-30T09:56:34.718Z", "3.0"),
+                new Sample("2015-09-30T09:57:35.040Z", "3.0"),
+                new Sample("2015-09-30T09:58:35.257Z", "3.0")
+        );
+    }
+
+    /**
+     * Issue #3047
+     * Test for counter aggregator documentation example.
+     *
+     * @see <a href="Counter Aggregator">https://github.com/axibase/atsd-docs/blob/master/api/sql/examples/counter-aggregator.md</a>
+     */
+    @Test
+    public void testCounterAggregator() {
+        String sqlQuery =
+                "SELECT datetime, count(value), max(value), first(value), last(value), counter(value), delta(value)\n" +
+                        "FROM 'sql-example-counter-aggregator-metric' \n" +
+                        "WHERE entity = 'sql-example-counter-aggregator-entity' AND tags.level = 'ERROR' \n" +
+                        "AND datetime >= '2015-09-30T09:00:00Z' AND datetime < '2015-09-30T10:00:00Z' \n" +
+                        "GROUP BY period(5 minute)";
+
+        StringTable resultTable = executeQuery(sqlQuery).readEntity(StringTable.class);
+
+        List<List<String>> expectedRows = Arrays.asList(
+                Arrays.asList("2015-09-30T09:00:00.000Z", "5", "3.0", "2.0", "3.0", "1.0", "1.0"),
+                Arrays.asList("2015-09-30T09:05:00.000Z", "4", "3.0", "3.0", "3.0", "0.0", "0.0"),
+                Arrays.asList("2015-09-30T09:10:00.000Z", "4", "3.0", "3.0", "3.0", "0.0", "0.0"),
+                Arrays.asList("2015-09-30T09:15:00.000Z", "6", "5.0", "2.0", "5.0", "5.0", "2.0"),
+                Arrays.asList("2015-09-30T09:20:00.000Z", "5", "8.0", "7.0", "8.0", "3.0", "3.0"),
+                Arrays.asList("2015-09-30T09:25:00.000Z", "4", "3.0", "3.0", "3.0", "3.0", "-5.0"),
+                Arrays.asList("2015-09-30T09:30:00.000Z", "4", "3.0", "3.0", "3.0", "0.0", "0.0"),
+                Arrays.asList("2015-09-30T09:35:00.000Z", "4", "3.0", "3.0", "3.0", "0.0", "0.0"),
+                Arrays.asList("2015-09-30T09:40:00.000Z", "10", "1803.0", "3.0", "1803.0", "1800.0", "1800.0"),
+                Arrays.asList("2015-09-30T09:45:00.000Z", "5", "1806.0", "1803.0", "1806.0", "3.0", "3.0"),
+                Arrays.asList("2015-09-30T09:50:00.000Z", "4", "3.0", "3.0", "3.0", "3.0", "-1803.0"),
+                Arrays.asList("2015-09-30T09:55:00.000Z", "5", "3.0", "2.0", "3.0", "3.0", "0.0")
+        );
+
+        assertTableRows(expectedRows, resultTable);
+    }
+}

--- a/src/test/java/com/axibase/tsd/api/method/sql/examples/SqlDateFormatExampleTest.java
+++ b/src/test/java/com/axibase/tsd/api/method/sql/examples/SqlDateFormatExampleTest.java
@@ -1,0 +1,69 @@
+package com.axibase.tsd.api.method.sql.examples;
+
+import com.axibase.tsd.api.method.sql.SqlTest;
+import com.axibase.tsd.api.model.series.Sample;
+import com.axibase.tsd.api.model.series.Series;
+import com.axibase.tsd.api.model.sql.StringTable;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * @authtor Igor Shmagrinskiy
+ */
+public class SqlDateFormatExampleTest extends SqlTest {
+    private static final String TEST_PREFIX = "sql-example-date-format-";
+
+    @BeforeClass
+    public static void prepareData() {
+        Series series = new Series(TEST_PREFIX + "entity", TEST_PREFIX + "metric");
+        sendSamplesToSeries(series,
+                new Sample("2016-04-09T14:00:01Z", "3.8"),
+                new Sample("2016-04-09T14:00:18Z", "14.0"),
+                new Sample("2016-04-09T14:00:34Z", "16.83"),
+                new Sample("2016-04-09T14:00:50Z", "10.2"),
+                new Sample("2016-04-09T14:01:06Z", "4.04"),
+                new Sample("2016-04-09T14:01:22Z", "9.0"),
+                new Sample("2016-04-09T14:01:38Z", "2.0"),
+                new Sample("2016-04-09T14:01:54Z", "8.0"),
+                new Sample("2016-04-09T14:02:10Z", "10.23"),
+                new Sample("2016-04-09T14:02:26Z", "14.0"),
+                new Sample("2016-04-09T14:02:42Z", "20.2")
+        );
+    }
+
+    /**
+     * Issue #3047
+     * Test for date format documentation example.
+     *
+     * @see <a href="Date format">https://github.com/axibase/atsd-docs/blob/master/api/sql/examples/datetime-format.md</a>
+     */
+    @Test
+    public void testDateTimeFormat() {
+        String sqlQuery =
+                "SELECT datetime, time, value\n" +
+                        "FROM 'sql-example-date-format-metric' \n" +
+                        "WHERE entity = 'sql-example-date-format-entity'\n" +
+                        "AND datetime BETWEEN '2016-04-09T14:00:00Z' AND '2016-04-09T14:05:00Z'";
+
+        StringTable resultTable = executeQuery(sqlQuery).readEntity(StringTable.class);
+
+        List<List<String>> expectedRows = Arrays.asList(
+                Arrays.asList("2016-04-09T14:00:01Z", "1428588001000", "3.8"),
+                Arrays.asList("2016-04-09T14:00:18Z", "1428588018000", "14"),
+                Arrays.asList("2016-04-09T14:00:34Z", "1428588034000", "16.83"),
+                Arrays.asList("2016-04-09T14:00:50Z", "1428588050000", "10.2"),
+                Arrays.asList("2016-04-09T14:01:06Z", "1428588066000", "4.04"),
+                Arrays.asList("2016-04-09T14:01:22Z", "1428588082000", "9"),
+                Arrays.asList("2016-04-09T14:01:38Z", "1428588098000", "2"),
+                Arrays.asList("2016-04-09T14:01:54Z", "1428588114000", "8"),
+                Arrays.asList("2016-04-09T14:02:10Z", "1428588130000", "10.23"),
+                Arrays.asList("2016-04-09T14:02:26Z", "1428588146000", "14"),
+                Arrays.asList("2016-04-09T14:02:42Z", "1428588162000", "20.2")
+        );
+
+        assertTableRows(expectedRows, resultTable);
+    }
+}

--- a/src/test/java/com/axibase/tsd/api/method/sql/examples/SqlFilterByTagExampleTest.java
+++ b/src/test/java/com/axibase/tsd/api/method/sql/examples/SqlFilterByTagExampleTest.java
@@ -1,0 +1,75 @@
+package com.axibase.tsd.api.method.sql.examples;
+
+import com.axibase.tsd.api.method.sql.SqlTest;
+import com.axibase.tsd.api.model.series.Sample;
+import com.axibase.tsd.api.model.series.Series;
+import com.axibase.tsd.api.model.sql.StringTable;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+
+/**
+ * @author Igor Shmagrinskiy
+ */
+public class SqlFilterByTagExampleTest extends SqlTest {
+    private static final String TEST_PREFIX = "sql-example-filter-by-tags-";
+
+    @BeforeClass
+    public static void prepareData() {
+        Series series = new Series(TEST_PREFIX + "entity", TEST_PREFIX + "metric");
+        series.addTag("file_system", "/dev/mapper/vg_nurswgvml007-lv_root");
+        sendSamplesToSeries(series,
+                new Sample(1446033205000L, "72.2738"),
+                new Sample(1446033220000L, "72.275"),
+                new Sample(1446033236000L, "72.2697"),
+                new Sample(1446033282000L, "72.2749"),
+                new Sample(1446033297000L, "72.2763"),
+                new Sample(1446033312000L, "72.2706"),
+                new Sample(1446033327000L, "72.2722"),
+                new Sample(1446033342000L, "72.2736"),
+                new Sample(1446033357000L, "72.2747")
+        );
+        series.setTags(Collections.unmodifiableMap(new HashMap<String, String>() {{
+            put("file_system", "a");
+        }}));
+        sendSamplesToSeries(series,
+                new Sample(1446033342002L, "72.27556")
+        );
+    }
+
+    /**
+     * Issue #3047
+     * Test for filter by tag documentation example.
+     *
+     * @see <a href="Filter By Tag">https://github.com/axibase/atsd-docs/blob/master/api/sql/examples/filter-by-tag.md</a>
+     */
+    @Test
+    public void testDateTimeFormat() {
+        String sqlQuery =
+                "SELECT time, value, tags.file_system \n" +
+                        "FROM 'sql-example-filter-by-tags-metric' \n" +
+                        "WHERE entity = 'sql-example-filter-by-tags-entity'\n" +
+                        "AND tags.file_system LIKE '/d%' \n" +
+                        "AND time between 1446033205000 AND 1446033357001";
+
+        StringTable resultTable = executeQuery(sqlQuery).readEntity(StringTable.class);
+
+        List<List<String>> expectedRows = Arrays.asList(
+                Arrays.asList("1446033205000", "72.2738", "/dev/mapper/vg_nurswgvml007-lv_root"),
+                Arrays.asList("1446033220000", "72.275", "/dev/mapper/vg_nurswgvml007-lv_root"),
+                Arrays.asList("1446033236000", "72.2697", "/dev/mapper/vg_nurswgvml007-lv_root"),
+                Arrays.asList("1446033282000", "72.2749", "/dev/mapper/vg_nurswgvml007-lv_root"),
+                Arrays.asList("1446033297000", "72.2763", "/dev/mapper/vg_nurswgvml007-lv_root"),
+                Arrays.asList("1446033312000", "72.2706", "/dev/mapper/vg_nurswgvml007-lv_root"),
+                Arrays.asList("1446033327000", "72.2722", "/dev/mapper/vg_nurswgvml007-lv_root"),
+                Arrays.asList("1446033342000", "72.2736", "/dev/mapper/vg_nurswgvml007-lv_root"),
+                Arrays.asList("1446033357000", "72.2747", "/dev/mapper/vg_nurswgvml007-lv_root")
+        );
+
+        assertTableRows(expectedRows, resultTable);
+    }
+}

--- a/src/test/java/com/axibase/tsd/api/method/sql/examples/SqlFilterNullTagExampleTest.java
+++ b/src/test/java/com/axibase/tsd/api/method/sql/examples/SqlFilterNullTagExampleTest.java
@@ -1,0 +1,129 @@
+package com.axibase.tsd.api.method.sql.examples;
+
+import com.axibase.tsd.api.method.entity.EntityMethod;
+import com.axibase.tsd.api.method.sql.SqlTest;
+import com.axibase.tsd.api.model.entity.Entity;
+import com.axibase.tsd.api.model.series.Sample;
+import com.axibase.tsd.api.model.series.Series;
+import com.axibase.tsd.api.model.sql.StringTable;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.*;
+
+/**
+ * @author Igor Shmagrinskiy
+ */
+public class SqlFilterNullTagExampleTest extends SqlTest {
+    private final static String TEST_PREFIX = "sql-operator-is-null-";
+
+
+    @BeforeClass
+    public static void prepareData() {
+        final Series series = new Series(TEST_PREFIX + "entity-1", TEST_PREFIX + "metric") {{
+            setTags(Collections.unmodifiableMap(new HashMap<String, String>() {{
+                put("tag1", "val1");
+            }}));
+        }};
+
+        //Update series' entity
+        updateSeriesEntityTags(
+                series,
+                Collections.unmodifiableMap(new HashMap<String, String>() {{
+                    put("tag1", "val1");
+                }})
+        );
+
+        sendSamplesToSeries(series, new Sample("2016-06-19T11:00:00.000Z", 1));
+        series.setEntity(TEST_PREFIX + "entity-2");
+        series.setTags(Collections.
+                unmodifiableMap(new HashMap<String, String>() {{
+                                    put("tag1", "val2");
+                                    put("tag2", "val2");
+                                }}
+                ));
+        sendSamplesToSeries(series, new Sample("2016-06-19T11:05:00.000Z", 2));
+        series.setEntity(TEST_PREFIX + "entity-3");
+        series.setTags(Collections.unmodifiableMap(new HashMap<String, String>() {
+            {
+                put("tag2", "val3");
+            }
+        }));
+        sendSamplesToSeries(series, new Sample("2016-06-19T11:10:00.000Z", 3));
+        series.setEntity(TEST_PREFIX + "entity-4");
+        series.setTags(Collections.unmodifiableMap(new HashMap<String, String>() {
+            {
+                put("tag4", "val4");
+            }
+        }));
+        sendSamplesToSeries(series, new Sample("2016-06-19T11:15:00.000Z", 4));
+    }
+
+    /**
+     * Following tests related to #2937 issue.
+     */
+
+    private static void updateSeriesEntityTags(final Series series, final Map<String, String> newTags) {
+        try {
+            EntityMethod.updateEntity(new Entity() {{
+                setName(series.getEntity());
+                setTags(newTags);
+            }});
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to update Entity tags");
+        }
+    }
+
+    /**
+     * Issue #3047
+     * Test for filter by tag documentation example.
+     *
+     * @see <a href="Select Series without Specified Tag">https://github.com/axibase/atsd-docs/blob/master/api/sql/examples/filter-null-tag.md#select-series-without-specified-tag</a>
+     */
+    @Test
+    public void testFilterNullTagByIsNullOperator() {
+        String sqlQuery =
+                "SELECT entity, datetime, value, tags.*\n" +
+                        "FROM 'sql-operator-is-null-metric'\n" +
+                        "WHERE datetime >= '2016-06-19T11:00:00.000Z' and datetime < '2016-06-19T11:11:00.000Z'\n" +
+                        "AND tags.tag4 IS NULL\n";
+
+        StringTable resultTable = executeQuery(sqlQuery).readEntity(StringTable.class);
+
+
+        List<List<String>> expectedRows = Arrays.asList(
+                Arrays.asList("sql-operator-is-null-entity-1", "2016-06-19T11:00:00.000Z", "1", "null", "null", "val1"),
+                Arrays.asList("sql-operator-is-null-entity-2", "2016-06-19T11:05:00.000Z", "2", "null", "val2", "val2"),
+                Arrays.asList("sql-operator-is-null-entity-3", "2016-06-19T11:10:00.000Z", "3", "null", "val3", "null")
+        );
+
+        assertTableRows(expectedRows, resultTable);
+    }
+
+
+    /**
+     * Issue #3047
+     * Test for filter by tag documentation example.
+     *
+     * @see <a href="Alternative using NOT tags.{name} != ''">https://github.com/axibase/atsd-docs/blob/master/api/sql/examples/filter-null-tag.md#alternative-using-not-tagsname--</a>
+     */
+    @Test
+    public void testFilterNullTagByNotEqualsOperator() {
+        String sqlQuery =
+                "SELECT entity, datetime, value, tags.*\n" +
+                        "FROM 'sql-operator-is-null-metric'\n" +
+                        "WHERE datetime >= '2016-06-19T11:00:00.000Z' and datetime < '2016-06-19T11:11:00.000Z'\n" +
+                        "AND NOT tags.tag4 != ''\n";
+
+        StringTable resultTable = executeQuery(sqlQuery).readEntity(StringTable.class);
+
+
+        List<List<String>> expectedRows = Arrays.asList(
+                Arrays.asList("sql-operator-is-null-entity-1", "2016-06-19T11:00:00.000Z", "1", "null", "null", "val1"),
+                Arrays.asList("sql-operator-is-null-entity-2", "2016-06-19T11:05:00.000Z", "2", "null", "val2", "val2"),
+                Arrays.asList("sql-operator-is-null-entity-3", "2016-06-19T11:10:00.000Z", "3", "null", "val3", "null")
+        );
+
+        assertTableRows(expectedRows, resultTable);
+    }
+}

--- a/src/test/java/com/axibase/tsd/api/method/sql/examples/SqlGroupByWithOrderByExampleTest.java
+++ b/src/test/java/com/axibase/tsd/api/method/sql/examples/SqlGroupByWithOrderByExampleTest.java
@@ -1,0 +1,73 @@
+package com.axibase.tsd.api.method.sql.examples;
+
+import com.axibase.tsd.api.method.sql.SqlTest;
+import com.axibase.tsd.api.model.series.Sample;
+import com.axibase.tsd.api.model.series.Series;
+import com.axibase.tsd.api.model.sql.StringTable;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * @author Igor Shmagrinskiy
+ */
+public class SqlGroupByWithOrderByExampleTest extends SqlTest {
+    private static final String TEST_PREFIX = "sql-example-group-by-with-order-by-";
+
+    @BeforeClass
+    public static void prepareData() {
+        Series series = new Series(TEST_PREFIX + "entity-1", TEST_PREFIX + "metric");
+        sendSamplesToSeries(series,
+                new Sample("2016-06-19T11:00:00.000Z", "46.547288888888865")
+        );
+        series.setEntity(TEST_PREFIX + "entity-2");
+        sendSamplesToSeries(series,
+                new Sample("2016-06-19T11:00:00.000Z", "21.85551111111111")
+        );
+
+        series.setEntity(TEST_PREFIX + "entity-3");
+        sendSamplesToSeries(series,
+                new Sample("2016-06-19T11:00:00.000Z", "13.554488888888887")
+        );
+
+        series.setEntity(TEST_PREFIX + "entity-4");
+        sendSamplesToSeries(series,
+                new Sample("2016-06-19T11:00:00.000Z", "7.88160714285714")
+        );
+
+        series.setEntity(TEST_PREFIX + "entity-5");
+        sendSamplesToSeries(series,
+                new Sample("2016-06-19T11:00:00.000Z", "2.8021973094170405")
+        );
+    }
+
+    /**
+     * Issue #3047
+     * Test for GROUP BY Query with ORDER BY documentation example.
+     *
+     * @see <a href="GROUP BY Query with ORDER BY">https://github.com/axibase/atsd-docs/blob/master/api/sql/examples/group-by-query-with-order-by.md</a>
+     */
+    @Test
+    public void testGroupByWithOrderBy() {
+        String sqlQuery =
+                "SELECT entity, avg(value) \n" +
+                        "FROM 'sql-example-group-by-with-order-by-metric' \n" +
+                        "WHERE datetime >= '2016-06-19T11:00:00.000Z' \n" +
+                        "GROUP BY entity \n" +
+                        "ORDER BY avg(value) DESC";
+
+        StringTable resultTable = executeQuery(sqlQuery).readEntity(StringTable.class);
+
+        List<List<String>> expectedRows = Arrays.asList(
+                Arrays.asList(TEST_PREFIX + "entity-1", "46.547288888888865"),
+                Arrays.asList(TEST_PREFIX + "entity-2", "21.85551111111111"),
+                Arrays.asList(TEST_PREFIX + "entity-3", "13.554488888888887"),
+                Arrays.asList(TEST_PREFIX + "entity-4", "7.88160714285714"),
+                Arrays.asList(TEST_PREFIX + "entity-5", "2.8021973094170405")
+        );
+
+        assertTableRows(expectedRows, resultTable);
+    }
+}

--- a/src/test/java/com/axibase/tsd/api/method/sql/examples/SqlGroupHavingExampleTest.java
+++ b/src/test/java/com/axibase/tsd/api/method/sql/examples/SqlGroupHavingExampleTest.java
@@ -1,0 +1,9 @@
+package com.axibase.tsd.api.method.sql.examples;
+
+import com.axibase.tsd.api.method.sql.SqlTest;
+
+/**
+ * @author Igor Shmagrinskiy
+ */
+public class SqlGroupHavingExampleTest extends SqlTest {
+}

--- a/src/test/java/com/axibase/tsd/api/method/sql/examples/SqlGroupedAverageExampleTest.java
+++ b/src/test/java/com/axibase/tsd/api/method/sql/examples/SqlGroupedAverageExampleTest.java
@@ -1,0 +1,70 @@
+package com.axibase.tsd.api.method.sql.examples;
+
+import com.axibase.tsd.api.method.sql.SqlTest;
+import com.axibase.tsd.api.model.series.Sample;
+import com.axibase.tsd.api.model.series.Series;
+import com.axibase.tsd.api.model.sql.StringTable;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * @author Igor Shmagrinskiy
+ */
+public class SqlGroupedAverageExampleTest extends SqlTest {
+    private static final String TEST_PREFIX = "sql-example-grouped-average-";
+
+    @BeforeClass
+    public static void prepareData() {
+        Series series = new Series(TEST_PREFIX + "entity", TEST_PREFIX + "metric");
+        sendSamplesToSeries(series,
+                new Sample(1446037200000L, "76.94454545454546"),
+                new Sample(1446037500000L, "24.44388888888889"),
+                new Sample(1446037800000L, "19.04421052631579"),
+                new Sample(1446038100000L, "17.453157894736844"),
+                new Sample(1446038400000L, "17.373157894736842"),
+                new Sample(1446038700000L, "19.232222222222223"),
+                new Sample(1446039000000L, "35.061052631578946"),
+                new Sample(1446039300000L, "28.737894736842104"),
+                new Sample(1446039600000L, "24.24578947368421"),
+                new Sample(1446039900000L, "15.909444444444444"),
+                new Sample(1446040200000L, "16.4")
+        );
+    }
+
+    /**
+     * Issue #3047
+     * Test for Grouped Average  documentation example.
+     *
+     * @see <a href="Grouped Average">https://github.com/axibase/atsd-docs/blob/master/api/sql/examples/grouped-average.md</a>
+     */
+    @Test
+    public void testGroupedAverage() {
+        String sqlQuery =
+                "SELECT entity, period(5 MINUTE) AS \"period\", avg(value)\n" +
+                        "  FROM 'sql-example-grouped-average-metric' \n" +
+                        "WHERE entity IN ('sql-example-grouped-average-entity') \n" +
+                        "  AND time >= 1446037200000\n" +
+                        "  GROUP BY entity, period(5 MINUTE)";
+
+        StringTable resultTable = executeQuery(sqlQuery).readEntity(StringTable.class);
+
+        List<List<String>> expectedRows = Arrays.asList(
+                Arrays.asList(TEST_PREFIX + "entity", "1446037200000", "76.94454545454546"),
+                Arrays.asList(TEST_PREFIX + "entity", "1446037500000", "24.44388888888889"),
+                Arrays.asList(TEST_PREFIX + "entity", "1446037800000", "19.04421052631579"),
+                Arrays.asList(TEST_PREFIX + "entity", "1446038100000", "17.453157894736844"),
+                Arrays.asList(TEST_PREFIX + "entity", "1446038400000", "17.373157894736842"),
+                Arrays.asList(TEST_PREFIX + "entity", "1446038700000", "19.232222222222223"),
+                Arrays.asList(TEST_PREFIX + "entity", "1446039000000", "35.061052631578946"),
+                Arrays.asList(TEST_PREFIX + "entity", "1446039300000", "28.737894736842104"),
+                Arrays.asList(TEST_PREFIX + "entity", "1446039600000", "24.24578947368421"),
+                Arrays.asList(TEST_PREFIX + "entity", "1446039900000", "15.909444444444444"),
+                Arrays.asList(TEST_PREFIX + "entity", "1446040200000", "16.4")
+        );
+
+        assertTableRows(expectedRows, resultTable);
+    }
+}

--- a/src/test/java/com/axibase/tsd/api/method/sql/examples/SqlGroupedHavingExampleTest.java
+++ b/src/test/java/com/axibase/tsd/api/method/sql/examples/SqlGroupedHavingExampleTest.java
@@ -1,0 +1,9 @@
+package com.axibase.tsd.api.method.sql.examples;
+
+import com.axibase.tsd.api.method.sql.SqlTest;
+
+/**
+ * @author Igor Shmagrinskiy
+ */
+public class SqlGroupedHavingExampleTest extends SqlTest {
+}

--- a/src/test/java/com/axibase/tsd/api/method/sql/examples/SqlInterpolateEdgesExampleTest.java
+++ b/src/test/java/com/axibase/tsd/api/method/sql/examples/SqlInterpolateEdgesExampleTest.java
@@ -1,0 +1,9 @@
+package com.axibase.tsd.api.method.sql.examples;
+
+import com.axibase.tsd.api.method.sql.SqlTest;
+
+/**
+ * @author Igor Shmagrinskiy
+ */
+public class SqlInterpolateEdgesExampleTest extends SqlTest {
+}

--- a/src/test/java/com/axibase/tsd/api/method/sql/examples/SqlInterpolateExampleTest.java
+++ b/src/test/java/com/axibase/tsd/api/method/sql/examples/SqlInterpolateExampleTest.java
@@ -1,0 +1,9 @@
+package com.axibase.tsd.api.method.sql.examples;
+
+import com.axibase.tsd.api.method.sql.SqlTest;
+
+/**
+ * @author Igor Shmagrinskiy
+ */
+public class SqlInterpolateExampleTest extends SqlTest {
+}

--- a/src/test/java/com/axibase/tsd/api/method/sql/examples/SqlJoinDerivedSeriesExampleTest.java
+++ b/src/test/java/com/axibase/tsd/api/method/sql/examples/SqlJoinDerivedSeriesExampleTest.java
@@ -1,0 +1,9 @@
+package com.axibase.tsd.api.method.sql.examples;
+
+import com.axibase.tsd.api.method.sql.SqlTest;
+
+/**
+ * @author Igor Shmagrinskiy
+ */
+public class SqlJoinDerivedSeriesExampleTest extends SqlTest {
+}

--- a/src/test/java/com/axibase/tsd/api/method/sql/examples/SqlJoinExampleTest.java
+++ b/src/test/java/com/axibase/tsd/api/method/sql/examples/SqlJoinExampleTest.java
@@ -1,0 +1,9 @@
+package com.axibase.tsd.api.method.sql.examples;
+
+import com.axibase.tsd.api.method.sql.SqlTest;
+
+/**
+ * @author Igor Shmagrinskiy
+ */
+public class SqlJoinExampleTest extends SqlTest {
+}

--- a/src/test/java/com/axibase/tsd/api/method/sql/examples/SqlJoinUsingEntityExampleTest.java
+++ b/src/test/java/com/axibase/tsd/api/method/sql/examples/SqlJoinUsingEntityExampleTest.java
@@ -1,0 +1,9 @@
+package com.axibase.tsd.api.method.sql.examples;
+
+import com.axibase.tsd.api.method.sql.SqlTest;
+
+/**
+ * @author Igor Shmagrinskiy
+ */
+public class SqlJoinUsingEntityExampleTest extends SqlTest {
+}

--- a/src/test/java/com/axibase/tsd/api/method/sql/examples/SqlLastTimeExampleTest.java
+++ b/src/test/java/com/axibase/tsd/api/method/sql/examples/SqlLastTimeExampleTest.java
@@ -1,0 +1,9 @@
+package com.axibase.tsd.api.method.sql.examples;
+
+import com.axibase.tsd.api.method.sql.SqlTest;
+
+/**
+ * @author Igor Shmagrinskiy
+ */
+public class SqlLastTimeExampleTest extends SqlTest {
+}

--- a/src/test/java/com/axibase/tsd/api/method/sql/examples/SqlMaxValueTimeExampleTest.java
+++ b/src/test/java/com/axibase/tsd/api/method/sql/examples/SqlMaxValueTimeExampleTest.java
@@ -1,0 +1,9 @@
+package com.axibase.tsd.api.method.sql.examples;
+
+import com.axibase.tsd.api.method.sql.SqlTest;
+
+/**
+ * @author Igor Shmagrinskiy
+ */
+public class SqlMaxValueTimeExampleTest extends SqlTest {
+}

--- a/src/test/java/com/axibase/tsd/api/method/sql/examples/SqlOrderByTimeExampleTest.java
+++ b/src/test/java/com/axibase/tsd/api/method/sql/examples/SqlOrderByTimeExampleTest.java
@@ -1,0 +1,9 @@
+package com.axibase.tsd.api.method.sql.examples;
+
+import com.axibase.tsd.api.method.sql.SqlTest;
+
+/**
+ * @author Igor  Shmagrinskiy
+ */
+public class SqlOrderByTimeExampleTest extends SqlTest {
+}

--- a/src/test/java/com/axibase/tsd/api/method/sql/examples/SqlOuterJoinWithAggregationExampleTest.java
+++ b/src/test/java/com/axibase/tsd/api/method/sql/examples/SqlOuterJoinWithAggregationExampleTest.java
@@ -1,0 +1,9 @@
+package com.axibase.tsd.api.method.sql.examples;
+
+import com.axibase.tsd.api.method.sql.SqlTest;
+
+/**
+ * @author Igor Shmagrinskiy
+ */
+public class SqlOuterJoinWithAggregationExampleTest extends SqlTest {
+}

--- a/src/test/java/com/axibase/tsd/api/method/sql/examples/SqlRowNumberTopNTagsExampleTest.java
+++ b/src/test/java/com/axibase/tsd/api/method/sql/examples/SqlRowNumberTopNTagsExampleTest.java
@@ -1,0 +1,9 @@
+package com.axibase.tsd.api.method.sql.examples;
+
+import com.axibase.tsd.api.method.sql.SqlTest;
+
+/**
+ * @author Igor Shmagrinskiy
+ */
+public class SqlRowNumberTopNTagsExampleTest extends SqlTest {
+}

--- a/src/test/java/com/axibase/tsd/api/method/sql/examples/SqlSelectAllExampleTest.java
+++ b/src/test/java/com/axibase/tsd/api/method/sql/examples/SqlSelectAllExampleTest.java
@@ -1,0 +1,9 @@
+package com.axibase.tsd.api.method.sql.examples;
+
+import com.axibase.tsd.api.method.sql.SqlTest;
+
+/**
+ * @author Igor Shmagrinskiy
+ */
+public class SqlSelectAllExampleTest extends SqlTest {
+}

--- a/src/test/java/com/axibase/tsd/api/method/sql/examples/SqlSelectEntityTagsAsColumnsExampleTest.java
+++ b/src/test/java/com/axibase/tsd/api/method/sql/examples/SqlSelectEntityTagsAsColumnsExampleTest.java
@@ -1,0 +1,9 @@
+package com.axibase.tsd.api.method.sql.examples;
+
+import com.axibase.tsd.api.method.sql.SqlTest;
+
+/**
+ * @author Igor Shmagrinskiy
+ */
+public class SqlSelectEntityTagsAsColumnsExampleTest extends SqlTest {
+}


### PR DESCRIPTION
## Examples' tests

| Document | Done |  Test | Passed |
| --- | --- | --- | --- |
| [alias.md](https://github.com/axibase/atsd-docs/blob/master/api/sql/examples/alias.md "alias.md") | Yes | [SqlAliasExampleTest](SqlAliasExampleTest.java) | Yes |
| [all-tags.md](https://github.com/axibase/atsd-docs/blob/master/api/sql/examples/all-tags.md "all-tags.md") | Yes | [SqlAllTagsTest](SqlAllTagsExampleTest.java) | No |
| [average-value.md](https://github.com/axibase/atsd-docs/blob/master/api/sql/examples/average-value.md "average-value.md") | Yes | [SqlAvgValueExampleTest](SqlAvgValueExampleTest.java)| Yes |
| [counter-aggregator.md](https://github.com/axibase/atsd-docs/blob/master/api/sql/examples/counter-aggregator.md "counter-aggregator.md")  | Yes | [SqlCounterAggregatorExampleTest](SqlCounterAggregatorExampleTest.java) | Yes |
| [datetime-format.md](https://github.com/axibase/atsd-docs/blob/master/api/sql/examples/datetime-format.md "datetime-format.md") | Yes | [SqlDateFormatExampleTest](SqlDateFormatExampleTest.java) | No |
| [filter-by-tag.md](https://github.com/axibase/atsd-docs/blob/master/api/sql/examples/filter-by-tag.md "filter-by-tag.md") | Yes | [SqlFilterByTagExampleTest](SqlFilterByTagExampleTest.java) | No |
| [filter-null-tag.md](https://github.com/axibase/atsd-docs/blob/master/api/sql/examples/filter-null-tag.md "filter-null-tag.md") | Yes | [SqlFilterNullTagExampleTest](SqlFilterNullTagExampleTest.java) | Yes |
| [group-by-query-with-order-by.md](https://github.com/axibase/atsd-docs/blob/master/api/sql/examples/group-by-query-with-order-by.md "group-by-query-with-order-by.md") | Yes | [SqlGroupByWithOrderByExampleTest](SqlGroupByWithOrderByExampleTest.java) | Yes |
