### PR TITLE
Entity command test

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -115,6 +115,12 @@
             <artifactId>jersey-apache-connector</artifactId>
             <version>${jersey.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <version>RELEASE</version>
+            <scope>test</scope>
+        </dependency>
 
 
     </dependencies>

--- a/src/test/java/com/axibase/tsd/api/method/entity/EntityCommandTest.java
+++ b/src/test/java/com/axibase/tsd/api/method/entity/EntityCommandTest.java
@@ -1,0 +1,71 @@
+
+        package com.axibase.tsd.api.method.entity;
+
+        import com.axibase.tsd.api.Registry;
+        import com.axibase.tsd.api.model.entity.Entity;
+        import org.junit.Test;
+
+        import javax.ws.rs.core.EntityTag;
+        import javax.ws.rs.core.Response;
+        import javax.ws.rs.core.StreamingOutput;
+
+        import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
+        import static javax.ws.rs.core.Response.Status.OK;
+        import static org.junit.Assert.assertEquals;
+        import static org.junit.Assert.assertTrue;
+
+public class EntityCommandTest extends EntityMethod {
+
+    @Test
+    public void testAddNewEntityTagsForNewEntity() throws Exception {
+        Entity entity_name_for_tags = new Entity("e-for-test-add-tags");
+        createOrReplaceEntity(entity_name_for_tags);
+        entity_name_for_tags.addTag("e-tag-1", "e-val-1");
+        createOrReplaceEntity(entity_name_for_tags);
+
+        Response entity_name_for_tags_get = getEntity("e-for-test-add-tags");
+        Entity entity_name_for_tags_get_to_ent = entity_name_for_tags_get.readEntity(Entity.class);
+
+        assertEquals("Method should fail if new entity tags don't add for existing entity ",entity_name_for_tags.getTags(), entity_name_for_tags_get_to_ent.getTags());
+
+    }
+
+    @Test
+    public void testUpdateEntityTagsForExistEntity() throws Exception {
+        Entity entity_name_for_tags = new Entity("e-for-test-update-tags");
+        entity_name_for_tags.addTag("e-tag-1", "e-val-1");
+        createOrReplaceEntity(entity_name_for_tags);
+        entity_name_for_tags.addTag("e-tag-2", "e-val-2");
+        createOrReplaceEntity(entity_name_for_tags);
+
+        Response entity_name_for_tags_get = getEntity("e-for-test-update-tags");
+        Entity entity_name_for_tags_get_to_ent = entity_name_for_tags_get.readEntity(Entity.class);
+
+        assertEquals("Method should fail if existing entity tags don't updated",entity_name_for_tags.getTags(), entity_name_for_tags_get_to_ent.getTags());
+
+    }
+
+    //test
+    @Test
+    public void testNewEntityTagsForExistEntity() throws Exception {
+        Entity entity_name_for_tags = new Entity("ent-for-test-add-tags");
+        entity_name_for_tags.addTag("e-tag-1", "e-val-1");
+        createOrReplaceEntity(entity_name_for_tags);
+
+        Response entity_name_for_tags_get = getEntity("ent-for-test-add-tags");
+        Entity entity_name_for_tags_get_to_ent = entity_name_for_tags_get.readEntity(Entity.class);
+
+        assertEquals("Method should fail if new entity tags don't create",entity_name_for_tags.getTags(), entity_name_for_tags_get_to_ent.getTags());
+
+    }
+
+    @Test
+    public void testAddNewEntityTagsMailformedForNewEntity() throws Exception {
+        Entity entity_name_for_tags = new Entity("ent-for-test-add-tags-mailformed");
+        entity_name_for_tags.addTag("hello 1", "world");
+        assertEquals("Method should fail if entityTag name contains whitespace", BAD_REQUEST.getStatusCode(), createOrReplaceEntity(entity_name_for_tags).getStatus());
+    }
+}
+
+
+

--- a/src/test/java/com/axibase/tsd/api/method/entity/EntityCommandTest.java
+++ b/src/test/java/com/axibase/tsd/api/method/entity/EntityCommandTest.java
@@ -1,69 +1,77 @@
 
-        package com.axibase.tsd.api.method.entity;
+package com.axibase.tsd.api.method.entity;
 
-        import com.axibase.tsd.api.Registry;
-        import com.axibase.tsd.api.model.entity.Entity;
-        import org.junit.Test;
-
-        import javax.ws.rs.core.EntityTag;
-        import javax.ws.rs.core.Response;
-        import javax.ws.rs.core.StreamingOutput;
-
-        import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
-        import static javax.ws.rs.core.Response.Status.OK;
-        import static org.junit.Assert.assertEquals;
-        import static org.junit.Assert.assertTrue;
+import com.axibase.tsd.api.model.entity.Entity;
+import org.junit.Test;
+import javax.ws.rs.core.Response;
+import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
+import static org.junit.Assert.assertEquals;
 
 public class EntityCommandTest extends EntityMethod {
 
+    /**
+     * Issue #3111
+     */
+
     @Test
     public void testAddNewEntityTagsForNewEntity() throws Exception {
-        Entity entity_name_for_tags = new Entity("e-for-test-add-tags");
-        createOrReplaceEntity(entity_name_for_tags);
-        entity_name_for_tags.addTag("e-tag-1", "e-val-1");
-        createOrReplaceEntity(entity_name_for_tags);
+        Entity EntityNameForTags = new Entity("e-for-test-add-tags");
+        createOrReplaceEntity(EntityNameForTags);
+        EntityNameForTags.addTag("e-tag-1", "e-val-1");
+        createOrReplaceEntity(EntityNameForTags);
 
-        Response entity_name_for_tags_get = getEntity("e-for-test-add-tags");
-        Entity entity_name_for_tags_get_to_ent = entity_name_for_tags_get.readEntity(Entity.class);
+        Response EntityNameForTagsGet = getEntity("e-for-test-add-tags");
+        Entity EntityNameForTagsGetToEnt = EntityNameForTagsGet.readEntity(Entity.class);
 
-        assertEquals("Method should fail if new entity tags don't add for existing entity ",entity_name_for_tags.getTags(), entity_name_for_tags_get_to_ent.getTags());
+        assertEquals("Method should fail if new entity tags don't add for existing entity ",EntityNameForTags.getTags(), EntityNameForTagsGetToEnt.getTags());
 
     }
+
+    /**
+     * Issue #3111
+     */
 
     @Test
     public void testUpdateEntityTagsForExistEntity() throws Exception {
-        Entity entity_name_for_tags = new Entity("e-for-test-update-tags");
-        entity_name_for_tags.addTag("e-tag-1", "e-val-1");
-        createOrReplaceEntity(entity_name_for_tags);
-        entity_name_for_tags.addTag("e-tag-2", "e-val-2");
-        createOrReplaceEntity(entity_name_for_tags);
+        Entity EntityNameForTags = new Entity("e-for-test-update-tags");
+        EntityNameForTags.addTag("e-tag-1", "e-val-1");
+        createOrReplaceEntity(EntityNameForTags);
+        EntityNameForTags.addTag("e-tag-2", "e-val-2");
+        createOrReplaceEntity(EntityNameForTags);
 
-        Response entity_name_for_tags_get = getEntity("e-for-test-update-tags");
-        Entity entity_name_for_tags_get_to_ent = entity_name_for_tags_get.readEntity(Entity.class);
+        Response EntityNameForTagsGet = getEntity("e-for-test-update-tags");
+        Entity EntityNameForTagsGetToEnt = EntityNameForTagsGet.readEntity(Entity.class);
 
-        assertEquals("Method should fail if existing entity tags don't updated",entity_name_for_tags.getTags(), entity_name_for_tags_get_to_ent.getTags());
+        assertEquals("Entity tags are not updated.",EntityNameForTags.getTags(), EntityNameForTagsGetToEnt.getTags());
 
     }
 
-    //test
+    /**
+     * Issue #3111
+     */
+
     @Test
     public void testNewEntityTagsForExistEntity() throws Exception {
-        Entity entity_name_for_tags = new Entity("ent-for-test-add-tags");
-        entity_name_for_tags.addTag("e-tag-1", "e-val-1");
-        createOrReplaceEntity(entity_name_for_tags);
+        Entity EntityNameForTags = new Entity("ent-for-test-add-tags");
+        EntityNameForTags.addTag("e-tag-1", "e-val-1");
+        createOrReplaceEntity(EntityNameForTags);
 
-        Response entity_name_for_tags_get = getEntity("ent-for-test-add-tags");
-        Entity entity_name_for_tags_get_to_ent = entity_name_for_tags_get.readEntity(Entity.class);
+        Response EntityNameForTagsGet = getEntity("ent-for-test-add-tags");
+        Entity EntityNameForTagsGetToEnt = EntityNameForTagsGet.readEntity(Entity.class);
 
-        assertEquals("Method should fail if new entity tags don't create",entity_name_for_tags.getTags(), entity_name_for_tags_get_to_ent.getTags());
+        assertEquals("Method should fail if new entity tags don't create",EntityNameForTags.getTags(), EntityNameForTagsGetToEnt.getTags());
 
     }
+
+    /**
+     * Issue #3111
+     */
 
     @Test
     public void testAddNewEntityTagsMailformedForNewEntity() throws Exception {
-        Entity entity_name_for_tags = new Entity("ent-for-test-add-tags-mailformed");
-        entity_name_for_tags.addTag("hello 1", "world");
-        assertEquals("Method should fail if entityTag name contains whitespace", BAD_REQUEST.getStatusCode(), createOrReplaceEntity(entity_name_for_tags).getStatus());
+        Entity EntityNameForTags = new Entity("ent-for-test-add-tags-mailformed");
+        EntityNameForTags.addTag("hello 1", "world");
+        assertEquals("EntityTag name contains whitespace. Insert Entity tag is failed.", BAD_REQUEST.getStatusCode(), createOrReplaceEntity(EntityNameForTags).getStatus());
     }
 }
 

--- a/src/test/java/com/axibase/tsd/api/method/entity/EntityCommandTest.java
+++ b/src/test/java/com/axibase/tsd/api/method/entity/EntityCommandTest.java
@@ -1,20 +1,18 @@
-
 package com.axibase.tsd.api.method.entity;
 
 import com.axibase.tsd.api.model.entity.Entity;
-import org.junit.Test;
 import javax.ws.rs.core.Response;
 import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
-import static org.junit.Assert.assertEquals;
+import static org.testng.AssertJUnit.assertEquals;
 
-public class EntityCommandTest extends EntityMethod {
+public class EntityCommandTest extends EntityMethod{
 
     /**
      * Issue #3111
      */
 
-    @Test
-    public void testAddNewEntityTagsForNewEntity() throws Exception {
+    @org.testng.annotations.Test
+    public void testTestAddNewEntityTagsForNewEntity() throws Exception {
         Entity EntityNameForTags = new Entity("e-for-test-add-tags");
         createOrReplaceEntity(EntityNameForTags);
         EntityNameForTags.addTag("e-tag-1", "e-val-1");
@@ -24,14 +22,13 @@ public class EntityCommandTest extends EntityMethod {
         Entity EntityNameForTagsGetToEnt = EntityNameForTagsGet.readEntity(Entity.class);
 
         assertEquals("Method should fail if new entity tags don't add for existing entity ",EntityNameForTags.getTags(), EntityNameForTagsGetToEnt.getTags());
-
     }
 
     /**
      * Issue #3111
      */
 
-    @Test
+    @org.testng.annotations.Test
     public void testUpdateEntityTagsForExistEntity() throws Exception {
         Entity EntityNameForTags = new Entity("e-for-test-update-tags");
         EntityNameForTags.addTag("e-tag-1", "e-val-1");
@@ -50,7 +47,7 @@ public class EntityCommandTest extends EntityMethod {
      * Issue #3111
      */
 
-    @Test
+    @org.testng.annotations.Test
     public void testNewEntityTagsForExistEntity() throws Exception {
         Entity EntityNameForTags = new Entity("ent-for-test-add-tags");
         EntityNameForTags.addTag("e-tag-1", "e-val-1");
@@ -60,20 +57,17 @@ public class EntityCommandTest extends EntityMethod {
         Entity EntityNameForTagsGetToEnt = EntityNameForTagsGet.readEntity(Entity.class);
 
         assertEquals("Method should fail if new entity tags don't create",EntityNameForTags.getTags(), EntityNameForTagsGetToEnt.getTags());
-
     }
 
     /**
      * Issue #3111
      */
 
-    @Test
+    @org.testng.annotations.Test
     public void testAddNewEntityTagsMailformedForNewEntity() throws Exception {
         Entity EntityNameForTags = new Entity("ent-for-test-add-tags-mailformed");
         EntityNameForTags.addTag("hello 1", "world");
         assertEquals("EntityTag name contains whitespace. Insert Entity tag is failed.", BAD_REQUEST.getStatusCode(), createOrReplaceEntity(EntityNameForTags).getStatus());
     }
+
 }
-
-
-

--- a/src/test/java/com/axibase/tsd/api/model/entity/Entity.java
+++ b/src/test/java/com/axibase/tsd/api/model/entity/Entity.java
@@ -17,6 +17,16 @@ public class Entity {
     private Date lastInsertDate;
     private Map<String, String> tags;
 
+    public Boolean getEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(Boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    private Boolean enabled;
+
     public Entity() {
 
     }

--- a/src/test/java/com/axibase/tsd/api/model/entity/Entity.java
+++ b/src/test/java/com/axibase/tsd/api/model/entity/Entity.java
@@ -16,15 +16,6 @@ public class Entity {
     private String name;
     private Date lastInsertDate;
     private Map<String, String> tags;
-
-    public Boolean getEnabled() {
-        return enabled;
-    }
-
-    public void setEnabled(Boolean enabled) {
-        this.enabled = enabled;
-    }
-
     private Boolean enabled;
 
     public Entity() {
@@ -36,6 +27,13 @@ public class Entity {
             Registry.Entity.register(name);
         }
         this.name = name;
+    }
+    public Boolean getEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(Boolean enabled) {
+        this.enabled = enabled;
     }
 
     public String getName() {
@@ -58,7 +56,7 @@ public class Entity {
     }
 
     public Map<String, String> getTags() {
-        if(tags == null) {
+        if (tags == null) {
             return null;
         }
         return new HashMap<>(tags);


### PR DESCRIPTION
Entity Command Test:
- [x] For existing entity: new entity-tags added and existing entity-tags updated
- [x] For new entity: entity created with specified entity-tags
- [x] Malformed: command fails if entity-tag name contains whitespace, e.g. t:"hello 1"=world