### PR TITLE
Add Entity Command Test

### DIFF
--- a/src/test/java/com/axibase/tsd/api/method/entity/EntityCommandTest.java
+++ b/src/test/java/com/axibase/tsd/api/method/entity/EntityCommandTest.java
@@ -1,0 +1,74 @@
+package com.axibase.tsd.api.method.entity;
+
+import com.axibase.tsd.api.model.entity.Entity;
+import javax.ws.rs.core.Response;
+import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
+import static org.testng.AssertJUnit.assertEquals;
+
+public class EntityCommandTest extends EntityMethod{
+
+    /**
+     * Issue #3111
+     */
+
+    @org.testng.annotations.Test
+    public void testTestAddNewEntityTagsForNewEntity() throws Exception {
+        Entity EntityNameForTags = new Entity("e-for-test-add-tags");
+        createOrReplaceEntity(EntityNameForTags);
+        EntityNameForTags.addTag("e-tag-1", "e-val-1");
+        createOrReplaceEntity(EntityNameForTags);
+
+        Response EntityNameForTagsGet = getEntity("e-for-test-add-tags");
+        Entity EntityNameForTagsGetToEnt = EntityNameForTagsGet.readEntity(Entity.class);
+
+        assertEquals("Method should fail if new entity tags don't add for existing entity ",EntityNameForTags.getTags(), EntityNameForTagsGetToEnt.getTags());
+    }
+
+    /**
+     * Issue #3111
+     */
+
+    @org.testng.annotations.Test
+    public void testUpdateEntityTagsForExistEntity() throws Exception {
+        Entity EntityNameForTags = new Entity("e-for-test-update-tags");
+        EntityNameForTags.addTag("e-tag-1", "e-val-1");
+        createOrReplaceEntity(EntityNameForTags);
+        EntityNameForTags.addTag("e-tag-2", "e-val-2");
+        createOrReplaceEntity(EntityNameForTags);
+
+        Response EntityNameForTagsGet = getEntity("e-for-test-update-tags");
+        Entity EntityNameForTagsGetToEnt = EntityNameForTagsGet.readEntity(Entity.class);
+
+        assertEquals("Entity tags are not updated.",EntityNameForTags.getTags(), EntityNameForTagsGetToEnt.getTags());
+
+    }
+
+    /**
+     * Issue #3111
+     */
+
+    @org.testng.annotations.Test
+    public void testNewEntityTagsForExistEntity() throws Exception {
+        Entity EntityNameForTags = new Entity("ent-for-test-add-tags");
+        EntityNameForTags.addTag("e-tag-1", "e-val-1");
+        createOrReplaceEntity(EntityNameForTags);
+
+        Response EntityNameForTagsGet = getEntity("ent-for-test-add-tags");
+        Entity EntityNameForTagsGetToEnt = EntityNameForTagsGet.readEntity(Entity.class);
+
+        assertEquals("Method should fail if new entity tags don't create",EntityNameForTags.getTags(), EntityNameForTagsGetToEnt.getTags());
+        //s
+    }
+
+    /**
+     * Issue #3111
+     */
+
+    @org.testng.annotations.Test
+    public void testAddNewEntityTagsMailformedForNewEntity() throws Exception {
+        Entity EntityNameForTags = new Entity("ent-for-test-add-tags-mailformed");
+        EntityNameForTags.addTag("hello 1", "world");
+        assertEquals("EntityTag name contains whitespace. Insert Entity tag is failed.", BAD_REQUEST.getStatusCode(), createOrReplaceEntity(EntityNameForTags).getStatus());
+    }
+
+}

--- a/src/test/java/com/axibase/tsd/api/model/entity/Entity.java
+++ b/src/test/java/com/axibase/tsd/api/model/entity/Entity.java
@@ -57,7 +57,7 @@ public class Entity {
     }
 
     public Map<String, String> getTags() {
-        if (tags == null) {
+        if(tags == null) {
             return null;
         }
         return new HashMap<>(tags);

--- a/src/test/java/com/axibase/tsd/api/model/entity/Entity.java
+++ b/src/test/java/com/axibase/tsd/api/model/entity/Entity.java
@@ -28,6 +28,7 @@ public class Entity {
         }
         this.name = name;
     }
+
     public Boolean getEnabled() {
         return enabled;
     }

--- a/src/test/java/com/axibase/tsd/api/model/entity/Entity.java
+++ b/src/test/java/com/axibase/tsd/api/model/entity/Entity.java
@@ -16,6 +16,7 @@ public class Entity {
     private String name;
     private Date lastInsertDate;
     private Map<String, String> tags;
+    private Boolean enabled;
 
     public Entity() {
 
@@ -26,6 +27,13 @@ public class Entity {
             Registry.Entity.register(name);
         }
         this.name = name;
+    }
+    public Boolean getEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(Boolean enabled) {
+        this.enabled = enabled;
     }
 
     public String getName() {
@@ -48,7 +56,7 @@ public class Entity {
     }
 
     public Map<String, String> getTags() {
-        if(tags == null) {
+        if (tags == null) {
             return null;
         }
         return new HashMap<>(tags);


### PR DESCRIPTION
Tests:
- [x] For existing entity: new entity-tags added and existing entity-tags updated
- [x] For new entity: entity created with specified entity-tags
- [x] Malformed: command fails if entity-tag name contains whitespace, e.g. t:"hello 1"=world