### PR TITLE
SQL: LOOKUP function to perform a value replacement #3555 + LOOKUP function doesn't support tags, entity.tags, metric.tags fields #3769

### DIFF
--- a/src/test/java/com/axibase/tsd/api/method/replacementtable/ReplacementTableMethod.java
+++ b/src/test/java/com/axibase/tsd/api/method/replacementtable/ReplacementTableMethod.java
@@ -1,0 +1,38 @@
+package com.axibase.tsd.api.method.replacementtable;
+
+
+import com.axibase.tsd.api.method.BaseMethod;
+import com.axibase.tsd.api.model.replacementtable.ReplacementTable;
+
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.Form;
+import javax.ws.rs.core.Response;
+import java.io.UnsupportedEncodingException;
+import java.util.Map;
+
+public class ReplacementTableMethod extends BaseMethod{
+    private static final String PATH = "/entities/lookup";
+    private static final WebTarget resource = httpRootResource.path(PATH);
+
+    public static void create(ReplacementTable table) throws UnsupportedEncodingException {
+        Form form = new Form();
+        form.param("lookupName", table.getName());
+        form.param("items", squashMapIntoString(table.getMap()));
+        form.param("oldName", "");
+        form.param("save", "Save");
+
+        Response response = resource
+                .request()
+                .post(Entity.form(form));
+        response.bufferEntity();
+    }
+
+    private static String squashMapIntoString(Map<String, String> map){
+        StringBuilder sb = new StringBuilder();
+        for (Map.Entry<String, String> entry : map.entrySet()) {
+            sb.append(entry.getKey()).append("=").append(entry.getValue()).append("\n");
+        }
+        return sb.toString();
+    }
+}

--- a/src/test/java/com/axibase/tsd/api/method/replacementtable/ReplacementTableMethod.java
+++ b/src/test/java/com/axibase/tsd/api/method/replacementtable/ReplacementTableMethod.java
@@ -3,29 +3,41 @@ package com.axibase.tsd.api.method.replacementtable;
 
 import com.axibase.tsd.api.method.BaseMethod;
 import com.axibase.tsd.api.model.replacementtable.ReplacementTable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.Form;
+import javax.ws.rs.core.MultivaluedHashMap;
+import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
 import java.io.UnsupportedEncodingException;
 import java.util.Map;
 
 public class ReplacementTableMethod extends BaseMethod{
+    private static final Logger logger = LoggerFactory.getLogger(ReplacementTableMethod.class);
     private static final String PATH = "/entities/lookup";
     private static final WebTarget resource = httpRootResource.path(PATH);
 
     public static void create(ReplacementTable table) throws UnsupportedEncodingException {
-        Form form = new Form();
-        form.param("lookupName", table.getName());
-        form.param("items", squashMapIntoString(table.getMap()));
-        form.param("oldName", "");
-        form.param("save", "Save");
+        MultivaluedMap<String, String> parameters = new MultivaluedHashMap<>();
+        parameters.add("lookupName", table.getName());
+        parameters.add("items", squashMapIntoString(table.getMap()));
+        parameters.add("oldName", "");
+        parameters.add("save", "Save");
+        Form form = new Form(parameters);
 
         Response response = resource
                 .request()
                 .post(Entity.form(form));
         response.bufferEntity();
+
+        if (!(response.getStatus() == Response.Status.OK.getStatusCode() || response.getStatus() == Response.Status.FOUND.getStatusCode())) {
+            String errorMessage = "Wasn't able to create a replacement table, Status Code is " + response.getStatusInfo();
+            logger.error(errorMessage);
+            throw new IllegalStateException(errorMessage);
+        }
     }
 
     private static String squashMapIntoString(Map<String, String> map){

--- a/src/test/java/com/axibase/tsd/api/method/replacementtable/ReplacementTableMethod.java
+++ b/src/test/java/com/axibase/tsd/api/method/replacementtable/ReplacementTableMethod.java
@@ -1,6 +1,5 @@
 package com.axibase.tsd.api.method.replacementtable;
 
-
 import com.axibase.tsd.api.method.BaseMethod;
 import com.axibase.tsd.api.model.replacementtable.ReplacementTable;
 import org.slf4j.Logger;
@@ -15,7 +14,7 @@ import javax.ws.rs.core.Response;
 import java.io.UnsupportedEncodingException;
 import java.util.Map;
 
-public class ReplacementTableMethod extends BaseMethod{
+public class ReplacementTableMethod extends BaseMethod {
     private static final Logger logger = LoggerFactory.getLogger(ReplacementTableMethod.class);
     private static final String PATH = "/entities/lookup";
     private static final WebTarget resource = httpRootResource.path(PATH);
@@ -33,14 +32,16 @@ public class ReplacementTableMethod extends BaseMethod{
                 .post(Entity.form(form));
         response.bufferEntity();
 
-        if (!(response.getStatus() == Response.Status.OK.getStatusCode() || response.getStatus() == Response.Status.FOUND.getStatusCode())) {
-            String errorMessage = "Wasn't able to create a replacement table, Status Code is " + response.getStatusInfo();
+        if (!((response.getStatusInfo().getFamily() == Response.Status.Family.SUCCESSFUL) ||
+                (response.getStatus() == Response.Status.FOUND.getStatusCode())))
+        {
+            String errorMessage = "Wasn't able to create a replacement table, Status Info is " + response.getStatusInfo();
             logger.error(errorMessage);
             throw new IllegalStateException(errorMessage);
         }
     }
 
-    private static String squashMapIntoString(Map<String, String> map){
+    private static String squashMapIntoString(Map<String, String> map) {
         StringBuilder sb = new StringBuilder();
         for (Map.Entry<String, String> entry : map.entrySet()) {
             sb.append(entry.getKey()).append("=").append(entry.getValue()).append("\n");

--- a/src/test/java/com/axibase/tsd/api/method/replacementtable/ReplacementTableMethod.java
+++ b/src/test/java/com/axibase/tsd/api/method/replacementtable/ReplacementTableMethod.java
@@ -2,6 +2,7 @@ package com.axibase.tsd.api.method.replacementtable;
 
 import com.axibase.tsd.api.method.BaseMethod;
 import com.axibase.tsd.api.model.replacementtable.ReplacementTable;
+import org.glassfish.jersey.client.ClientProperties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -17,9 +18,9 @@ import java.util.Map;
 public class ReplacementTableMethod extends BaseMethod {
     private static final Logger logger = LoggerFactory.getLogger(ReplacementTableMethod.class);
     private static final String PATH = "/entities/lookup";
-    private static final WebTarget resource = httpRootResource.path(PATH);
+    private static final WebTarget resource = httpRootResource.path(PATH).property(ClientProperties.FOLLOW_REDIRECTS, false);
 
-    public static void create(ReplacementTable table) throws UnsupportedEncodingException {
+    protected static Response createResponse(ReplacementTable table) {
         MultivaluedMap<String, String> parameters = new MultivaluedHashMap<>();
         parameters.add("lookupName", table.getName());
         parameters.add("items", squashMapIntoString(table.getMap()));
@@ -32,9 +33,13 @@ public class ReplacementTableMethod extends BaseMethod {
                 .post(Entity.form(form));
         response.bufferEntity();
 
-        if (!((response.getStatusInfo().getFamily() == Response.Status.Family.SUCCESSFUL) ||
-                (response.getStatus() == Response.Status.FOUND.getStatusCode())))
-        {
+        return response;
+    }
+
+    public static void createCheck(ReplacementTable table) throws UnsupportedEncodingException {
+        Response response = createResponse(table);
+
+        if (response.getStatus() != Response.Status.FOUND.getStatusCode()) {
             String errorMessage = "Wasn't able to create a replacement table, Status Info is " + response.getStatusInfo();
             logger.error(errorMessage);
             throw new IllegalStateException(errorMessage);

--- a/src/test/java/com/axibase/tsd/api/method/replacementtable/ReplacementTableMethod.java
+++ b/src/test/java/com/axibase/tsd/api/method/replacementtable/ReplacementTableMethod.java
@@ -39,6 +39,7 @@ public class ReplacementTableMethod extends BaseMethod {
     public static void createCheck(ReplacementTable table) throws UnsupportedEncodingException {
         Response response = createResponse(table);
 
+        // Table is created iif we get code 302 -- FOUND - Redirect
         if (response.getStatus() != Response.Status.FOUND.getStatusCode()) {
             String errorMessage = "Wasn't able to create a replacement table, Status Info is " + response.getStatusInfo();
             logger.error(errorMessage);

--- a/src/test/java/com/axibase/tsd/api/method/replacementtable/ReplacementTableMethod.java
+++ b/src/test/java/com/axibase/tsd/api/method/replacementtable/ReplacementTableMethod.java
@@ -38,7 +38,7 @@ public class ReplacementTableMethod extends BaseMethod {
     public static void createCheck(ReplacementTable table) {
         Response response = createResponse(table);
 
-        // Table is created iif we get code 302 -- FOUND - Redirect
+        // It's confusing, but we get code 302 -- FOUND - Redirect, only if table was created
         if (response.getStatus() != Response.Status.FOUND.getStatusCode()) {
             String errorMessage = "Wasn't able to create a replacement table, Status Info is " + response.getStatusInfo();
             logger.error(errorMessage);

--- a/src/test/java/com/axibase/tsd/api/method/replacementtable/ReplacementTableMethod.java
+++ b/src/test/java/com/axibase/tsd/api/method/replacementtable/ReplacementTableMethod.java
@@ -12,7 +12,6 @@ import javax.ws.rs.core.Form;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
-import java.io.UnsupportedEncodingException;
 import java.util.Map;
 
 public class ReplacementTableMethod extends BaseMethod {
@@ -36,7 +35,7 @@ public class ReplacementTableMethod extends BaseMethod {
         return response;
     }
 
-    public static void createCheck(ReplacementTable table) throws UnsupportedEncodingException {
+    public static void createCheck(ReplacementTable table) {
         Response response = createResponse(table);
 
         // Table is created iif we get code 302 -- FOUND - Redirect

--- a/src/test/java/com/axibase/tsd/api/method/sql/operator/SqlLookupFunctionTest.java
+++ b/src/test/java/com/axibase/tsd/api/method/sql/operator/SqlLookupFunctionTest.java
@@ -1,0 +1,453 @@
+package com.axibase.tsd.api.method.sql.operator;
+
+import com.axibase.tsd.api.method.entity.EntityMethod;
+import com.axibase.tsd.api.method.metric.MetricMethod;
+import com.axibase.tsd.api.method.replacementtable.ReplacementTableMethod;
+import com.axibase.tsd.api.method.series.SeriesMethod;
+import com.axibase.tsd.api.method.sql.SqlTest;
+import com.axibase.tsd.api.model.entity.Entity;
+import com.axibase.tsd.api.model.metric.Metric;
+import com.axibase.tsd.api.model.replacementtable.ReplacementTable;
+import com.axibase.tsd.api.model.series.Sample;
+import com.axibase.tsd.api.model.series.Series;
+import com.axibase.tsd.api.model.series.TextSample;
+import com.axibase.tsd.api.util.Registry;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static com.axibase.tsd.api.util.Util.TestNames.entity;
+import static com.axibase.tsd.api.util.Util.TestNames.metric;
+
+public class SqlLookupFunctionTest extends SqlTest {
+    private static final String TEST_METRIC_NAME = metric();
+    private static final String TEST_METRIC_NAME1 = metric();
+    private static final String TEST_ENTITY_NAME = entity();
+    private static final String TEST_ENTITY_NAME1 = entity();
+
+    private static void prepareReplacementTable(String name) throws IOException {
+        ReplacementTable table = new ReplacementTable(name);
+
+        Registry.ReplacementTable.register(name);
+
+        table.addValue("-1", "negative");
+        table.addValue("1", "positive");
+        table.addValue("2", "2");
+        table.addValue("word", "3");
+        table.addValue("words", "letters");
+        table.addValue("3", "-3");
+        table.addValue("4", "3.14");
+        table.addValue("PI", "3.14");
+        table.addValue("3.14", "PI");
+
+        ReplacementTableMethod.create(table);
+    }
+
+    @BeforeClass
+    public static void prepareData() throws Exception {
+        prepareReplacementTable("tableForLookupTest1");
+        prepareReplacementTable("tableForLookupTest2");
+
+        List<Series> seriesList = new ArrayList<>();
+        {
+            Series series = new Series(TEST_ENTITY_NAME, TEST_METRIC_NAME);
+
+            series.addData(new TextSample("2016-06-03T09:20:00.000Z", "word"));
+            series.addData(new TextSample("2016-06-03T09:21:00.000Z", "-1"));
+            series.addData(new TextSample("2016-06-03T09:22:00.000Z", "1"));
+            series.addData(new TextSample("2016-06-03T09:23:00.000Z", "2"));
+            series.addData(new TextSample("2016-06-03T09:24:00.000Z", "word"));
+            series.addData(new TextSample("2016-06-03T09:25:00.000Z", "words"));
+            series.addData(new TextSample("2016-06-03T09:26:00.000Z", "3"));
+            series.addData(new TextSample("2016-06-03T09:27:00.000Z", "4"));
+            series.addData(new TextSample("2016-06-03T09:28:00.000Z", "PI"));
+            series.addData(new TextSample("2016-06-03T09:29:00.000Z", "3.14"));
+            series.addData(new TextSample("2016-06-03T09:30:00.000Z", "nothing"));
+            seriesList.add(series);
+        }
+
+
+        {
+            Map<String, String> tags = new HashMap<>();
+            tags.put("1", "-1");
+            tags.put("2", "1");
+            tags.put("3", "2");
+            tags.put("4", "word");
+            tags.put("5", "words");
+            tags.put("6", "3");
+            tags.put("7", "4");
+            tags.put("8", "PI");
+            tags.put("9", "3.14");
+            tags.put("10", "nothing");
+            Metric metric = new Metric(TEST_METRIC_NAME1);
+            metric.setTags(tags);
+            MetricMethod.createOrReplaceMetricCheck(metric);
+            Entity entity = new Entity(TEST_ENTITY_NAME1);
+            entity.setTags(tags);
+            EntityMethod.createOrReplaceEntityCheck(entity);
+
+            Series series = new Series();
+            series.setEntity(TEST_ENTITY_NAME1);
+            series.setMetric(TEST_METRIC_NAME1);
+            series.setTags(tags);
+            series.addData(new Sample("2016-06-03T09:20:00.000Z", "1"));
+            seriesList.add(series);
+        }
+
+
+        SeriesMethod.insertSeriesCheck(seriesList);
+    }
+
+    @DataProvider(name = "lookupTestTestProvider")
+    public Object[][] provideTestsDataForLookupTest() {
+        return new Object[][]{
+                {
+                        "1", "negative"
+                },
+                {
+                        "2", "positive"
+                },
+                {
+                        "3", "2"
+                },
+                {
+                        "4", "3"
+                },
+                {
+                        "5", "letters"
+                },
+                {
+                        "6", "-3"
+                },
+                {
+                        "7", "3.14"
+                },
+                {
+                        "8", "3.14"
+                },
+                {
+                        "9", "PI"
+                },
+                {
+                        "10", "null"
+                }
+
+        };
+    }
+
+    /**
+     * #3555
+     */
+    @Test
+    public void testLookupFromText() {
+        String sqlQuery = String.format(
+                "SELECT LOOKUP('table', t1.text) " +
+                        "FROM '%s' t1",
+                TEST_METRIC_NAME
+        );
+
+        String[][] expectedRows = { // values corresponding to Replacement Table
+                {"3"},              // if we consider t1.text as RT's key
+                {"negative"},
+                {"positive"},
+                {"2"},
+                {"3"},
+                {"letters"},
+                {"-3"},
+                {"3.14"},
+                {"3.14"},
+                {"PI"},
+                {"null"}
+        };
+
+        assertSqlQueryRows("LOOKUP gives wrong result", expectedRows, sqlQuery);
+    }
+
+    /**
+     * #3555
+     */
+    @Test
+    public void testDoubleLookupFromText() {
+        String sqlQuery = String.format(
+                "SELECT LOOKUP('table', LOOKUP('table', t1.text)) " +
+                        "FROM '%s' t1",
+                TEST_METRIC_NAME
+        );
+
+        String[][] expectedRows = { // looking twice in Replacement Table
+                {"-3"},             // first time -- just like before
+                {"null"},           // second time -- using values fromm 1st LOOKUP as new RT's keys
+                {"null"},
+                {"2"},
+                {"-3"},
+                {"null"},
+                {"null"},
+                {"PI"},
+                {"PI"},
+                {"3.14"},
+                {"null"}
+        };
+
+        assertSqlQueryRows("LOOKUP in LOOKUP gives wrong result", expectedRows, sqlQuery);
+    }
+
+    /**
+     * #3555
+     */
+    @Test
+    public void testLookupCaseSensitiveness() {
+        String sqlQuery = String.format(
+                "SELECT LOOKUP('table', 'Word'), LOOKUP('table', 'word') " +
+                        "FROM '%s' t1 " +
+                        "LIMIT 1",
+                TEST_METRIC_NAME
+        );
+
+        String[][] expectedRows = {
+                {"null", "3"}
+        };
+
+        assertSqlQueryRows("LOOKUP is not case-sensitive, as it should be", expectedRows, sqlQuery);
+    }
+
+    /**
+     * #3555
+     */
+    @Test
+    public void testLookupWithWrongTable() {
+        String sqlQuery = String.format(
+                "SELECT LOOKUP('noTable', t1.text) " +
+                        "FROM '%s' t1",
+                TEST_METRIC_NAME
+        );
+
+        String[][] expectedRows = {
+                {"null"},
+                {"null"},
+                {"null"},
+                {"null"},
+                {"null"},
+                {"null"},
+                {"null"},
+                {"null"},
+                {"null"},
+                {"null"},
+                {"null"}
+        };
+
+        assertSqlQueryRows("LOOKUP should return null with nonexist table", expectedRows, sqlQuery);
+    }
+
+    /**
+     * #3555
+     */
+    @Test
+    public void testLookupInWhere() {
+        String sqlQuery = String.format(
+                "SELECT t1.text " +
+                        "FROM '%s' t1 " +
+                        "WHERE LOOKUP('table', t1.text) IS NOT NULL",
+                TEST_METRIC_NAME
+        );
+
+        String[][] expectedRows = {
+                {"word"},
+                {"-1"},
+                {"1"},
+                {"2"},
+                {"word"},
+                {"words"},
+                {"3"},
+                {"4"},
+                {"PI"},
+                {"3.14"}
+        };
+
+        assertSqlQueryRows("LOOKUP in WHERE gives wrong result", expectedRows, sqlQuery);
+    }
+
+    /**
+     * #3555
+     */
+    @Test
+    public void testLookupInCast() {
+        String sqlQuery = String.format(
+                "SELECT CAST(LOOKUP('table', t1.text) as Number) " +
+                        "FROM '%s' t1",
+                TEST_METRIC_NAME
+        );
+
+        String[][] expectedRows = {
+                {"3"},
+                {"NaN"},
+                {"NaN"},
+                {"2"},
+                {"3"},
+                {"NaN"},
+                {"-3"},
+                {"3.14"},
+                {"3.14"},
+                {"NaN"},
+                {"NaN"}
+        };
+
+        assertSqlQueryRows("LOOKUP in CAST gives wrong result", expectedRows, sqlQuery);
+    }
+
+    /**
+     * #3555
+     */
+    @Test
+    public void testLookupInGroupBy() {
+        String sqlQuery = String.format(
+                "SELECT LOOKUP('table', t1.text), count(*) " +
+                        "FROM '%s' t1 " +
+                        "GROUP BY LOOKUP('table', t1.text) " +
+                        "ORDER BY 1 DESC",
+                TEST_METRIC_NAME
+        );
+
+        String[][] expectedRows = {
+                {"positive", "1"},
+                {"negative", "1"},
+                {"letters", "1"},
+                {"PI", "1"},
+                {"3.14", "2"},
+                {"3", "2"},
+                {"2", "1"},
+                {"-3", "1"},
+                {"null", "1"}
+        };
+
+        assertSqlQueryRows("LOOKUP in GROUP BY gives wrong result", expectedRows, sqlQuery);
+    }
+
+    /**
+     * #3555
+     */
+    @Test
+    public void testLookupInHaving() {
+        String sqlQuery = String.format(
+                "SELECT LOOKUP('table', t1.text), count(*) " +
+                        "FROM '%s' t1 " +
+                        "GROUP BY LOOKUP('table', t1.text) " +
+                        "HAVING sum(CAST(LOOKUP('table', t1.text) as Number)) > 0 " +
+                        "ORDER BY 1 DESC",
+                TEST_METRIC_NAME
+        );
+
+        String[][] expectedRows = {
+                {"3.14", "2"},
+                {"3", "2"},
+                {"2", "1"}
+        };
+
+        assertSqlQueryRows("LOOKUP in HAVING gives wrong result", expectedRows, sqlQuery);
+    }
+
+    /**
+     * #3555
+     */
+    @Test
+    public void testLookupInLength() {
+        String sqlQuery = String.format(
+                "SELECT LOOKUP('table', t1.text) " +
+                        "FROM '%s' t1 " +
+                        "WHERE LENGTH(LOOKUP('table', t1.text)) > 3",
+                TEST_METRIC_NAME
+        );
+
+        String[][] expectedRows = {
+                {"negative"},
+                {"positive"},
+                {"letters"},
+                {"3.14"},
+                {"3.14"}
+        };
+
+        assertSqlQueryRows("LOOKUP in LENGTH gives wrong result", expectedRows, sqlQuery);
+    }
+
+    /**
+     * #3555
+     */
+    @Test
+    public void testLookupWithLike() {
+        String sqlQuery = String.format(
+                "SELECT LOOKUP('table', t1.text) " +
+                        "FROM '%s' t1 " +
+                        "WHERE LOOKUP('table', t1.text) LIKE '3'",
+                TEST_METRIC_NAME
+        );
+
+        String[][] expectedRows = {
+                {"3"},
+                {"3"}
+        };
+
+        assertSqlQueryRows("LOOKUP with LIKE gives wrong result", expectedRows, sqlQuery);
+    }
+
+    /**
+     * #3769
+     */
+    @Test(dataProvider = "lookupTestTestProvider")
+    public void testLookupWithEntityTags(String key, String expectedResult) {
+        String sqlQuery = String.format(
+                "SELECT LOOKUP('table', t1.entity.tags.'%s') " +
+                        "FROM '%s' t1 ",
+                key,
+                TEST_METRIC_NAME1
+        );
+
+        String[][] expectedRows = {
+                {expectedResult}
+        };
+
+        assertSqlQueryRows("LOOKUP with entity.tags gives wrong result", expectedRows, sqlQuery);
+    }
+
+    /**
+     * #3769
+     */
+    @Test(dataProvider = "lookupTestTestProvider")
+    public void testLookupWithMetricTags(String key, String expectedResult) {
+        String sqlQuery = String.format(
+                "SELECT LOOKUP('table', t1.metric.tags.'%s') " +
+                        "FROM '%s' t1 ",
+                key,
+                TEST_METRIC_NAME1
+        );
+
+        String[][] expectedRows = {
+                {expectedResult}
+        };
+
+        assertSqlQueryRows("LOOKUP with metric tags gives wrong result", expectedRows, sqlQuery);
+    }
+
+    /**
+     * #3769
+     */
+    @Test(dataProvider = "lookupTestTestProvider")
+    public void testLookupWithSeriesTags(String key, String expectedResult) {
+        String sqlQuery = String.format(
+                "SELECT LOOKUP('table', t1.tags.'%s') " +
+                        "FROM '%s' t1 ",
+                key,
+                TEST_METRIC_NAME1
+        );
+
+        String[][] expectedRows = {
+                {expectedResult}
+        };
+
+        assertSqlQueryRows("LOOKUP with series tags gives wrong result", expectedRows, sqlQuery);
+    }
+}

--- a/src/test/java/com/axibase/tsd/api/method/sql/operator/SqlLookupFunctionTest.java
+++ b/src/test/java/com/axibase/tsd/api/method/sql/operator/SqlLookupFunctionTest.java
@@ -101,8 +101,8 @@ public class SqlLookupFunctionTest extends SqlTest {
         SeriesMethod.insertSeriesCheck(seriesList);
     }
 
-    @DataProvider(name = "lookupTestTestProvider")
-    public Object[][] provideTestsDataForLookupTest() {
+    @DataProvider(name = "lookupWithTagsTestProvider")
+    public Object[][] provideTestsDataForLookupWithTagsTest() {
         return new Object[][]{
                 {
                         "1", "negative"
@@ -394,7 +394,7 @@ public class SqlLookupFunctionTest extends SqlTest {
     /**
      * #3769
      */
-    @Test(dataProvider = "lookupTestTestProvider")
+    @Test(dataProvider = "lookupWithTagsTestProvider")
     public void testLookupWithEntityTags(String key, String expectedResult) {
         String sqlQuery = String.format(
                 "SELECT LOOKUP('table', t1.entity.tags.'%s') " +
@@ -413,7 +413,7 @@ public class SqlLookupFunctionTest extends SqlTest {
     /**
      * #3769
      */
-    @Test(dataProvider = "lookupTestTestProvider")
+    @Test(dataProvider = "lookupWithTagsTestProvider")
     public void testLookupWithMetricTags(String key, String expectedResult) {
         String sqlQuery = String.format(
                 "SELECT LOOKUP('table', t1.metric.tags.'%s') " +
@@ -432,7 +432,7 @@ public class SqlLookupFunctionTest extends SqlTest {
     /**
      * #3769
      */
-    @Test(dataProvider = "lookupTestTestProvider")
+    @Test(dataProvider = "lookupWithTagsTestProvider")
     public void testLookupWithSeriesTags(String key, String expectedResult) {
         String sqlQuery = String.format(
                 "SELECT LOOKUP('table', t1.tags.'%s') " +

--- a/src/test/java/com/axibase/tsd/api/method/sql/operator/SqlLookupFunctionTest.java
+++ b/src/test/java/com/axibase/tsd/api/method/sql/operator/SqlLookupFunctionTest.java
@@ -15,7 +15,6 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -27,22 +26,10 @@ import static com.axibase.tsd.api.util.Util.TestNames.metric;
 public class SqlLookupFunctionTest extends SqlTest {
     private static final String TEST_METRIC_NAME_BASE_LOOKUP_CASE = metric();
     private static final String TEST_METRIC_NAME_TAGS_CASE = metric();
-    private static final ReplacementTable TABLE_BASE_LOOKUP_TEST;
-    private static final ReplacementTable TABLE_TAGS_CASE;
-    static {
-        ReplacementTable table1;
-        ReplacementTable table2;
-        try {
-            table1 = prepareReplacementTable("tableForLookupTest1");
-            table2 = prepareReplacementTable("tableForLookupTest2");
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
-        TABLE_BASE_LOOKUP_TEST = table1;
-        TABLE_TAGS_CASE = table2;
-    }
+    private static final ReplacementTable TABLE_BASE_LOOKUP_TEST = prepareReplacementTable("tableForLookupTest1");
+    private static final ReplacementTable TABLE_TAGS_CASE = prepareReplacementTable("tableForLookupTest2");
 
-    private static ReplacementTable prepareReplacementTable(String name) throws IOException {
+    private static ReplacementTable prepareReplacementTable(String name) {
         ReplacementTable table = new ReplacementTable(name);
 
         table.addValue("-1", "negative");

--- a/src/test/java/com/axibase/tsd/api/method/sql/operator/SqlLookupFunctionTest.java
+++ b/src/test/java/com/axibase/tsd/api/method/sql/operator/SqlLookupFunctionTest.java
@@ -11,7 +11,6 @@ import com.axibase.tsd.api.model.replacementtable.ReplacementTable;
 import com.axibase.tsd.api.model.series.Sample;
 import com.axibase.tsd.api.model.series.Series;
 import com.axibase.tsd.api.model.series.TextSample;
-import com.axibase.tsd.api.util.Registry;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -33,8 +32,6 @@ public class SqlLookupFunctionTest extends SqlTest {
 
     private static void prepareReplacementTable(String name) throws IOException {
         ReplacementTable table = new ReplacementTable(name);
-
-        Registry.ReplacementTable.register(name);
 
         table.addValue("-1", "negative");
         table.addValue("1", "positive");

--- a/src/test/java/com/axibase/tsd/api/model/replacementtable/ReplacementTable.java
+++ b/src/test/java/com/axibase/tsd/api/model/replacementtable/ReplacementTable.java
@@ -1,5 +1,7 @@
 package com.axibase.tsd.api.model.replacementtable;
 
+import com.axibase.tsd.api.util.Registry;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -9,11 +11,13 @@ public class ReplacementTable {
 
 
     public ReplacementTable(String name, Map<String, String> map) {
+        Registry.ReplacementTable.register(name);
         this.name = name;
         this.map = map;
     }
 
     public ReplacementTable(String name) {
+        Registry.ReplacementTable.register(name);
         this.name = name;
     }
 

--- a/src/test/java/com/axibase/tsd/api/model/replacementtable/ReplacementTable.java
+++ b/src/test/java/com/axibase/tsd/api/model/replacementtable/ReplacementTable.java
@@ -1,0 +1,31 @@
+package com.axibase.tsd.api.model.replacementtable;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class ReplacementTable {
+    private String name = null;
+    private Map<String, String> map = new HashMap<>();
+
+
+    public ReplacementTable(String name, Map<String, String> map) {
+        this.name = name;
+        this.map = map;
+    }
+
+    public ReplacementTable(String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public Map<String, String> getMap() {
+        return map;
+    }
+
+    public void addValue(String key, String value){
+        map.put(key, value);
+    };
+}

--- a/src/test/java/com/axibase/tsd/api/util/Registry.java
+++ b/src/test/java/com/axibase/tsd/api/util/Registry.java
@@ -8,7 +8,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 public enum Registry {
-    Entity("Entity"), Metric("Metric"), Type("Type"), EntityGroup("EntityGroup");
+    Entity("Entity"), Metric("Metric"), Type("Type"), EntityGroup("EntityGroup"), ReplacementTable("ReplacementTable");
     final static String ERROR_ALREADY_REGISTRED_TPL = "REGISTRY ERROR: %s=%s already registered.";
     final static String ERROR_HAS_REGISTRED_PREFIX_TPL = "REGISTRY ERROR: %s=%s has registered prefix.";
     final static String ERROR_PREFIX_ALREADY_REGISTRED_TPL = "REGISTRY ERROR: %s prefix \"%s\" already registered.";


### PR DESCRIPTION
added tests for #3555