### PR TITLE
Bugfix: custom value deserializer and text samples mocks

### DIFF
--- a/src/test/java/com/axibase/tsd/api/method/series/SeriesQueryTest.java
+++ b/src/test/java/com/axibase/tsd/api/method/series/SeriesQueryTest.java
@@ -620,8 +620,11 @@ public class SeriesQueryTest extends SeriesMethod {
         Series series = Mocks.series();
         series.setData(Collections.singleton(Mocks.TEXT_SAMPLE));
         SeriesMethod.insertSeriesCheck(series);
+
         List<Series> resultSeriesList = SeriesMethod.executeQueryReturnSeries(new SeriesQuery(series));
-        assertEquals(Collections.singletonList(series), resultSeriesList);
+
+        String assertMessage = "SeriesList serialized as not expected!";
+        assertEquals(assertMessage, Collections.singletonList(series), resultSeriesList);
     }
 
     private void setRandomTimeDuringNextDay(Calendar calendar) {

--- a/src/test/java/com/axibase/tsd/api/method/series/SeriesQueryTest.java
+++ b/src/test/java/com/axibase/tsd/api/method/series/SeriesQueryTest.java
@@ -616,7 +616,7 @@ public class SeriesQueryTest extends SeriesMethod {
     }
 
     @Test
-    public void testSeriesQueryWithSampleWithoutValue() throws Exception {
+    public void testSeriesQueryWithTextSample() throws Exception {
         Series series = Mocks.series();
         series.setData(Collections.singleton(Mocks.TEXT_SAMPLE));
         SeriesMethod.insertSeriesCheck(series);

--- a/src/test/java/com/axibase/tsd/api/method/series/SeriesQueryTest.java
+++ b/src/test/java/com/axibase/tsd/api/method/series/SeriesQueryTest.java
@@ -584,7 +584,7 @@ public class SeriesQueryTest extends SeriesMethod {
         assertFalse("No series", seriesList.isEmpty());
         assertFalse("No series data", seriesList.get(0).getData().isEmpty());
         String received = seriesList.get(0).getData().get(0).getText();
-        assertEquals("Last version of text field incorrect", data[data.length-1], received);
+        assertEquals("Last version of text field incorrect", data[data.length - 1], received);
     }
 
     /**
@@ -613,6 +613,15 @@ public class SeriesQueryTest extends SeriesMethod {
         int receivedVersionsCount = receivedSeries.get(0).getData().size();
 
         assertEquals("Number of received versions mismatched", insertedVersionsCount, receivedVersionsCount);
+    }
+
+    @Test
+    public void testSeriesQueryWithSampleWithoutValue() throws Exception {
+        Series series = Mocks.series();
+        series.setData(Collections.singleton(Mocks.TEXT_SAMPLE));
+        SeriesMethod.insertSeriesCheck(series);
+        List<Series> resultSeriesList = SeriesMethod.executeQueryReturnSeries(new SeriesQuery(series));
+        assertEquals(Collections.singletonList(series), resultSeriesList);
     }
 
     private void setRandomTimeDuringNextDay(Calendar calendar) {

--- a/src/test/java/com/axibase/tsd/api/model/series/Sample.java
+++ b/src/test/java/com/axibase/tsd/api/model/series/Sample.java
@@ -1,9 +1,10 @@
 package com.axibase.tsd.api.model.series;
 
 import com.axibase.tsd.api.util.Util;
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
 import java.math.BigDecimal;
 import java.util.Date;
@@ -12,6 +13,9 @@ import java.util.Date;
 public class Sample {
     private String d;
     private Long t;
+
+    @JsonDeserialize(using = ValueDeserializer.class)
+    @JsonTypeInfo(use = JsonTypeInfo.Id.NONE)
     private BigDecimal v;
     private String text;
     private SampleVersion version;
@@ -56,8 +60,7 @@ public class Sample {
         this.v = v;
     }
 
-    @JsonCreator
-    public Sample(@JsonProperty("d") String d, @JsonProperty("v") String v) {
+    public Sample(String d, String v) {
         this.d = d;
         this.v = new BigDecimal(String.valueOf(v));
     }
@@ -86,20 +89,6 @@ public class Sample {
         this.v = v;
     }
 
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-
-        Sample sample = (Sample) o;
-
-        if (d != null ? !d.equals(sample.d) : sample.d != null) return false;
-        if (t != null ? !t.equals(sample.t) : sample.t != null) return false;
-        if (text != null ? !text.equals(sample.text) : sample.text != null) return false;
-        if (version != null ? !version.equals(sample.version) : sample.version != null) return false;
-
-        return v != null ? v.equals(sample.v) : sample.v == null;
-    }
 
     public String getText() {
         return text;
@@ -116,11 +105,31 @@ public class Sample {
     }
 
     @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || (!Sample.class.isInstance(o)))
+            return false;
+
+        Sample sample = (Sample) o;
+
+        if (d != null ? !d.equals(sample.d) : sample.d != null)
+            return false;
+        if (t != null ? !t.equals(sample.t) : sample.t != null)
+            return false;
+        if (v != null ? !v.equals(sample.v) : sample.v != null)
+            return false;
+        if (text != null ? !text.equals(sample.text) : sample.text != null)
+            return false;
+        return version != null ? version.equals(sample.version) : sample.version == null;
+    }
+
+    @Override
     public int hashCode() {
         int result = d != null ? d.hashCode() : 0;
         result = 31 * result + (t != null ? t.hashCode() : 0);
         result = 31 * result + (v != null ? v.hashCode() : 0);
         result = 31 * result + (text != null ? text.hashCode() : 0);
+        result = 31 * result + (version != null ? version.hashCode() : 0);
         return result;
     }
 

--- a/src/test/java/com/axibase/tsd/api/model/series/Series.java
+++ b/src/test/java/com/axibase/tsd/api/model/series/Series.java
@@ -105,23 +105,26 @@ public class Series {
 
         Series series = (Series) o;
 
-        if (entity != null ? !entity.equals(series.entity) : series.entity != null) return false;
-        if (metric != null ? !metric.equals(series.metric) : series.metric != null) return false;
-        if (data != null ? !data.equals(series.data) : series.data != null) return false;
-        return tags != null ? tags.equals(series.tags) : series.tags == null;
+        if (!entity.equals(series.entity))
+            return false;
+        if (!metric.equals(series.metric))
+            return false;
+        if (!data.equals(series.data))
+            return false;
+        return tags.equals(series.tags);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = entity.hashCode();
+        result = 31 * result + metric.hashCode();
+        result = 31 * result + data.hashCode();
+        result = 31 * result + tags.hashCode();
+        return result;
     }
 
     @Override
     public String toString() {
         return Util.prettyPrint(this);
-    }
-
-    @Override
-    public int hashCode() {
-        int result = entity != null ? entity.hashCode() : 0;
-        result = 31 * result + (metric != null ? metric.hashCode() : 0);
-        result = 31 * result + (data != null ? data.hashCode() : 0);
-        result = 31 * result + (tags != null ? tags.hashCode() : 0);
-        return result;
     }
 }

--- a/src/test/java/com/axibase/tsd/api/model/series/ValueDeserializer.java
+++ b/src/test/java/com/axibase/tsd/api/model/series/ValueDeserializer.java
@@ -1,0 +1,18 @@
+package com.axibase.tsd.api.model.series;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+
+
+public class ValueDeserializer extends JsonDeserializer<BigDecimal> {
+    @Override
+    public BigDecimal deserialize(JsonParser jsonParser, DeserializationContext deserializationContext)
+            throws IOException {
+        String stringValue = jsonParser.readValueAs(String.class);
+        return ("NaN".equals(stringValue)) ? null : new BigDecimal(stringValue);
+    }
+}

--- a/src/test/java/com/axibase/tsd/api/util/Mocks.java
+++ b/src/test/java/com/axibase/tsd/api/util/Mocks.java
@@ -6,7 +6,9 @@ import com.axibase.tsd.api.model.metric.Metric;
 import com.axibase.tsd.api.model.series.DataType;
 import com.axibase.tsd.api.model.series.Sample;
 import com.axibase.tsd.api.model.series.Series;
+import com.axibase.tsd.api.model.series.TextSample;
 
+import java.math.BigDecimal;
 import java.util.Collections;
 import java.util.Date;
 import java.util.Map;
@@ -17,7 +19,9 @@ public class Mocks {
     public static final String ISO_TIME = "2016-06-03T09:23:00.000Z";
     public static final Long MILLS_TIME = date().getTime();
     public static final String DECIMAL_VALUE = "123.4567";
-    public static final Sample SAMPLE = new Sample(ISO_TIME, DECIMAL_VALUE);
+    public static final String TEXT_VALUE = "text";
+    public static final Sample SAMPLE = new Sample(ISO_TIME, new BigDecimal(DECIMAL_VALUE), TEXT_VALUE);
+    public static final Sample TEXT_SAMPLE = new TextSample(ISO_TIME, TEXT_VALUE);
     public static final String TIMEZONE_ID = "GMT0";
     public static final String LABEL = "label";
     public static final String DESCRIPTION = "description";

--- a/src/test/java/com/axibase/tsd/api/util/Mocks.java
+++ b/src/test/java/com/axibase/tsd/api/util/Mocks.java
@@ -8,7 +8,6 @@ import com.axibase.tsd.api.model.series.Sample;
 import com.axibase.tsd.api.model.series.Series;
 import com.axibase.tsd.api.model.series.TextSample;
 
-import java.math.BigDecimal;
 import java.util.Collections;
 import java.util.Date;
 import java.util.Map;
@@ -20,7 +19,7 @@ public class Mocks {
     public static final Long MILLS_TIME = date().getTime();
     public static final String DECIMAL_VALUE = "123.4567";
     public static final String TEXT_VALUE = "text";
-    public static final Sample SAMPLE = new Sample(ISO_TIME, new BigDecimal(DECIMAL_VALUE), TEXT_VALUE);
+    public static final Sample SAMPLE = new Sample(ISO_TIME, DECIMAL_VALUE);
     public static final Sample TEXT_SAMPLE = new TextSample(ISO_TIME, TEXT_VALUE);
     public static final String TIMEZONE_ID = "GMT0";
     public static final String LABEL = "label";


### PR DESCRIPTION
# Description
- [x] Custom value deserializer `ValueDeserializer`, to deserialize `"NaN"` value as `null` 

- [x] Text samples in  `Mocks` class

- [x] Added test for this deserialization:  `testSeriesQueryWithSampleWithoutValue`