### PR TITLE
SQL: delta aggregator returns incorrect values when dates are filtered #3893

### DIFF
--- a/src/test/java/com/axibase/tsd/api/method/sql/function/dateformat/DateFormatInsideHavingClauseTest.java
+++ b/src/test/java/com/axibase/tsd/api/method/sql/function/dateformat/DateFormatInsideHavingClauseTest.java
@@ -1,0 +1,48 @@
+package com.axibase.tsd.api.method.sql.function.dateformat;
+
+import com.axibase.tsd.api.method.series.SeriesMethod;
+import com.axibase.tsd.api.method.sql.SqlTest;
+import com.axibase.tsd.api.model.series.Sample;
+import com.axibase.tsd.api.model.series.Series;
+import org.testng.annotations.Test;
+
+import java.util.Arrays;
+
+import static com.axibase.tsd.api.util.Util.TestNames.entity;
+import static com.axibase.tsd.api.util.Util.TestNames.metric;
+
+public class DateFormatInsideHavingClauseTest extends SqlTest {
+    /**
+     * #3893
+     */
+    @Test
+    public void testDateFormatInsideHavingGroupingByPeriod() throws Exception {
+        String entityName = entity();
+        String metric_name = metric();
+
+        Series series = new Series(entityName, metric_name);
+        series.setData(Arrays.asList(
+                new Sample("2017-02-09T12:00:00.000Z", "0"),
+                new Sample("2017-02-09T13:00:00.000Z", "0"),
+                new Sample("2017-02-10T12:00:00.000Z", "0"),
+                new Sample("2017-02-11T12:00:00.000Z", "0"),
+                new Sample("2017-02-12T12:00:00.000Z", "0")
+                )
+        );
+
+        SeriesMethod.insertSeriesCheck(series);
+
+        String sqlQuery = String.format(
+                "SELECT count(value) FROM '%s' " +
+                        "GROUP BY period(1 day) " +
+                        "HAVING date_format(time, 'u') = '4'",
+                metric_name
+        );
+
+        String[][] expectedRows = {
+                {"2"}
+        };
+
+        assertSqlQueryRows("Query with date_format inside HAVING gives wrong result", expectedRows, sqlQuery);
+    }
+}


### PR DESCRIPTION
added tests for #3893
Don't be confused by the name of this request.
Main problem of that bug was about HAVING clause not accepting a date_format function inside.