### PR TITLE
Delete the "timePrecision" field.

### DIFF
--- a/src/main/java/com/axibase/tsd/api/model/metric/Metric.java
+++ b/src/main/java/com/axibase/tsd/api/model/metric/Metric.java
@@ -4,10 +4,7 @@ import com.axibase.tsd.api.model.common.InterpolationMode;
 import com.axibase.tsd.api.model.series.DataType;
 import com.axibase.tsd.api.model.serialization.DateDeserializer;
 import com.axibase.tsd.api.util.Registry;
-import com.fasterxml.jackson.annotation.JsonAnyGetter;
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -31,7 +28,6 @@ public class Metric {
     private Boolean persistent;
     @JsonDeserialize(using = DateDeserializer.class)
     private ZonedDateTime createdDate;
-    private String timePrecision;
     private Integer retentionDays;
     private Integer seriesRetentionDays;
     private String invalidAction;

--- a/src/test/java/com/axibase/tsd/api/method/series/SeriesSearchTest.java
+++ b/src/test/java/com/axibase/tsd/api/method/series/SeriesSearchTest.java
@@ -40,7 +40,7 @@ public class SeriesSearchTest extends SeriesMethod {
 
     private final String[] entityFields = {"name", "label", "interpolate", "timezone", "enabled"};
     private final String[] metricFields = {"name", "label", "interpolate", "timezone", "enabled", "description",
-            "datatype", "timeprecision", "persistent", "filter", "retentiondays", "seriesretentiondays", "versioned",
+            "datatype", "persistent", "filter", "retentiondays", "seriesretentiondays", "versioned",
             "minvalue", "maxvalue", "invalidaction", "units"};
 
     @DataProvider
@@ -98,7 +98,6 @@ public class SeriesSearchTest extends SeriesMethod {
                 .setInterpolate(InterpolationMode.PREVIOUS)
                 .setDescription(prefix + Mocks.DESCRIPTION )
                 .setDataType(DataType.DECIMAL)
-                .setTimePrecision("SECONDS")
                 .setEnabled(true)
                 .setPersistent(true)
                 .setFilter("name = '*'")
@@ -209,7 +208,7 @@ public class SeriesSearchTest extends SeriesMethod {
         query.addEntityFields("interpolate", "timezone");
         query.addEntityTags("sst_11_entity_tag");
 
-        query.addMetricFields("datatype", "timeprecision");
+        query.addMetricFields("datatype");
         query.addMetricTags("sst_11_metric_tag");
 
         Entity entity1 = new Entity()
@@ -221,8 +220,7 @@ public class SeriesSearchTest extends SeriesMethod {
         Metric metirc1 = new Metric()
                 .setName(resultRecord1.getMetric().getName())
                 .setLabel(resultRecord1.getMetric().getLabel())
-                .setDataType(resultRecord1.getMetric().getDataType())
-                .setTimePrecision(resultRecord1.getMetric().getTimePrecision());
+                .setDataType(resultRecord1.getMetric().getDataType());
 
         SeriesSearchResultRecord expectedResult1 = new SeriesSearchResultRecord(
                 entity1,
@@ -241,7 +239,6 @@ public class SeriesSearchTest extends SeriesMethod {
                 .setName(resultRecord3.getMetric().getName())
                 .setLabel(resultRecord3.getMetric().getLabel())
                 .setDataType(resultRecord3.getMetric().getDataType())
-                .setTimePrecision(resultRecord3.getMetric().getTimePrecision())
                 .setTags(resultRecord3.getMetric().getTags());
 
         SeriesSearchResultRecord expectedResult3 = new SeriesSearchResultRecord(

--- a/src/test/java/com/axibase/tsd/api/method/sql/clause/select/SelectAliasSameAsColumnTest.java
+++ b/src/test/java/com/axibase/tsd/api/method/sql/clause/select/SelectAliasSameAsColumnTest.java
@@ -43,7 +43,6 @@ public class SelectAliasSameAsColumnTest extends SqlTest {
                 "    metric.interpolate AS \"metric.interpolate\",\n" +
                 "    metric.units AS \"metric.units\",\n" +
                 "    metric.timezone AS \"metric.timezone\",\n" +
-                "    metric.timePrecision AS \"metric.timePrecision\",\n" +
                 "    metric.enabled AS \"metric.enabled\",\n" +
                 "    metric.persistent AS \"metric.persistent\",\n" +
                 "    metric.filter AS \"metric.filter\",\n" +
@@ -87,7 +86,6 @@ public class SelectAliasSameAsColumnTest extends SqlTest {
                         "    metric.interpolate AS \"interpolate\",\n" +
                         "    metric.units AS \"units\",\n" +
                         "    metric.timezone AS \"timezone\",\n" +
-                        "    metric.timePrecision AS \"timePrecision\",\n" +
                         "    metric.enabled AS \"enabled\",\n" +
                         "    metric.persistent AS \"persistent\",\n" +
                         "    metric.filter AS \"filter\",\n" +

--- a/src/test/java/com/axibase/tsd/api/method/sql/clause/select/SqlSelectMetricFieldsTest.java
+++ b/src/test/java/com/axibase/tsd/api/method/sql/clause/select/SqlSelectMetricFieldsTest.java
@@ -29,7 +29,6 @@ public class SqlSelectMetricFieldsTest extends SqlTest {
         metric.setInterpolate(InterpolationMode.PREVIOUS);
         metric.setDescription(Mocks.DESCRIPTION);
         metric.setDataType(DataType.INTEGER);
-        metric.setTimePrecision("SECONDS");
         metric.setEnabled(true);
         metric.setPersistent(true);
         metric.setFilter("name = '*'");
@@ -56,7 +55,6 @@ public class SqlSelectMetricFieldsTest extends SqlTest {
                 {"interpolate", "PREVIOUS"},
                 {"description", Mocks.DESCRIPTION},
                 {"dataType", "INTEGER"},
-                {"timePrecision", "SECONDS"},
                 {"enabled", "true"},
                 {"persistent", "true"},
                 {"filter", "name = '*'"},


### PR DESCRIPTION
Delete the "timePrecision" metric's field from tests because it is also deleted from the ATSD metric object - ticket #5438.