### PR TITLE
5538: Fix testCanSetEmptyExpression()

### DIFF
--- a/src/test/java/com/axibase/tsd/api/method/entitygroup/EntityGroupUpdateTest.java
+++ b/src/test/java/com/axibase/tsd/api/method/entitygroup/EntityGroupUpdateTest.java
@@ -44,9 +44,10 @@ public class EntityGroupUpdateTest extends EntityGroupMethod {
         entityGroup.setExpression(SYNTAX_ALLOWED_ENTITYGROUP_EXPRESSION);
         createOrReplaceEntityGroupCheck(entityGroup);
 
-        entityGroup.setExpression("");
+        entityGroup.setExpression(" ");
 
         assertSame("Fail to execute updateEntityGroup query", Response.Status.Family.SUCCESSFUL, Util.responseFamily(updateEntityGroup(entityGroup)));
+        entityGroup.setExpression(entityGroup.getExpression().trim());
         assertTrue("Specified entityGroup does not exist", entityGroupExist(entityGroup));
     }
 


### PR DESCRIPTION
Tests are failing because of `javax.ws.rs.client.Entity#json` method, which does not send empty fields of the object. So, when we set `expression` field to an empty string, we don't send it to the server. According to [docs](https://github.com/axibase/atsd/blob/master/api/meta/entity-group/update.md) unspecified fields are left unchanged, that's why the test fails. 
I can't change `javax.ws.rs.client.Entity#json` method, I can't replace it. I tried to send a space character to force `javax.ws.rs.client.Entity#json` method send this field, but the ATSD trims the field before the storing, so the response for the GET method later does not contain `expression` field (it is empty after the trimming, `javax.ws.rs.client.Entity#json` doesn't send it) and the test fails. 
That's why my solution is so ugly, though it works. 