### PR TITLE
Increase dates of test messages.

### DIFF
--- a/src/test/java/com/axibase/tsd/api/method/message/MessageQueryTest.java
+++ b/src/test/java/com/axibase/tsd/api/method/message/MessageQueryTest.java
@@ -24,7 +24,7 @@ public class MessageQueryTest extends MessageMethod {
     static {
         message = new Message("message-query-test-timezone");
         message.setMessage("hello");
-        message.setDate("2018-05-21T00:00:00.000Z");
+        message.setDate("2105-05-21T00:00:00.000Z");
     }
 
     @BeforeMethod
@@ -37,7 +37,7 @@ public class MessageQueryTest extends MessageMethod {
     @Test
     public void testISOTimezoneZ() throws Exception {
         MessageQuery messageQuery = buildMessageQuery();
-        messageQuery.setStartDate("2018-05-21T00:00:00Z");
+        messageQuery.setStartDate("2105-05-21T00:00:00Z");
 
         List<Message> storedMessageList = queryMessageResponse(messageQuery).readEntity(new GenericType<List<Message>>() {
         });
@@ -52,7 +52,7 @@ public class MessageQueryTest extends MessageMethod {
     @Test
     public void testISOTimezonePlusHourMinute() throws Exception {
         MessageQuery messageQuery = buildMessageQuery();
-        messageQuery.setStartDate("2018-05-21T01:23:00+01:23");
+        messageQuery.setStartDate("2105-05-21T01:23:00+01:23");
 
         List<Message> storedMessageList = queryMessageResponse(messageQuery).readEntity(new GenericType<List<Message>>() {
         });
@@ -67,7 +67,7 @@ public class MessageQueryTest extends MessageMethod {
     @Test
     public void testISOTimezoneMinusHourMinute() throws Exception {
         MessageQuery messageQuery = buildMessageQuery();
-        messageQuery.setStartDate("2018-05-20T22:37:00-01:23");
+        messageQuery.setStartDate("2105-05-20T22:37:00-01:23");
 
         List<Message> storedMessageList = queryMessageResponse(messageQuery).readEntity(new GenericType<List<Message>>() {
         });
@@ -81,7 +81,7 @@ public class MessageQueryTest extends MessageMethod {
     @Issue("2850")
     @Test
     public void testLocalTimeUnsupported() throws Exception {
-        final String startDate = "2018-07-21 00:00:00";
+        final String startDate = "2105-07-21 00:00:00";
         MessageQuery messageQuery = buildMessageQuery().setStartDate(startDate);
 
         Response response = queryMessageResponse(messageQuery);
@@ -96,7 +96,7 @@ public class MessageQueryTest extends MessageMethod {
     @Test
     public void testRfc822TimezoneOffsetSupported() throws Exception {
         MessageQuery messageQuery = buildMessageQuery();
-        messageQuery.setStartDate("2018-05-20T22:50:00-0110");
+        messageQuery.setStartDate("2105-05-20T22:50:00-0110");
 
         Message storedMessage = queryMessageResponse(messageQuery)
                 .readEntity(new GenericType<List<Message>>() {})
@@ -124,7 +124,7 @@ public class MessageQueryTest extends MessageMethod {
     public void testEntitiesWildcardStarChar() throws Exception {
         Message message = new Message("message-query-wildcard-2-1");
         message.setMessage("msgtext");
-        message.setDate("2018-01-01T00:00:00.000Z");
+        message.setDate("2105-01-01T00:00:00.000Z");
         insertMessageCheck(message);
 
         Map<String, Object> query = new HashMap<>();
@@ -142,7 +142,7 @@ public class MessageQueryTest extends MessageMethod {
     public void testEntitiesWildcardQuestionChar() throws Exception {
         Message message = new Message("message-query-wildcard-3-1");
         message.setMessage("msgtext");
-        message.setDate("2018-01-01T00:00:00.000Z");
+        message.setDate("2105-01-01T00:00:00.000Z");
         insertMessageCheck(message);
 
         Map<String, Object> query = new HashMap<>();
@@ -160,7 +160,7 @@ public class MessageQueryTest extends MessageMethod {
     public void testEntityEntitiesWildcardSame() throws Exception {
         Message message = new Message("message-query-wildcard-4-1");
         message.setMessage("msgtext");
-        message.setDate("2018-01-01T00:00:00.000Z");
+        message.setDate("2105-01-01T00:00:00.000Z");
         insertMessageCheck(message);
         message.setEntity("message-query-wildcard-4-2");
         insertMessageCheck(message);


### PR DESCRIPTION
MessageQueryTest fails because dates of test messages are more than 1 year old. So increase dates of messages.