### PR TITLE
Test permutations of series transformations - fix data race bug.

### DIFF
--- a/src/main/java/com/axibase/tsd/api/model/series/query/SeriesQuery.java
+++ b/src/main/java/com/axibase/tsd/api/model/series/query/SeriesQuery.java
@@ -13,8 +13,10 @@ import com.axibase.tsd.api.model.series.query.transformation.rate.Rate;
 import com.axibase.tsd.api.model.series.query.transformation.smooth.Smooth;
 import com.axibase.tsd.api.util.Util;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.experimental.Accessors;
+import lombok.experimental.Wither;
 
 import java.util.HashMap;
 import java.util.List;
@@ -26,6 +28,7 @@ import static com.axibase.tsd.api.util.Util.MIN_QUERYABLE_DATE;
 @Data
 @Accessors(chain = true)
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@AllArgsConstructor
 public class SeriesQuery {
     private String entity;
     private String entityGroup;
@@ -53,7 +56,7 @@ public class SeriesQuery {
     private Boolean versioned;
     private Boolean addMeta;
     private SeriesType type;
-    private List<Transformation> transformationOrder;
+    @Wither private List<Transformation> transformationOrder;
 
     public SeriesQuery() {
     }

--- a/src/test/java/com/axibase/tsd/api/method/series/SeriesQueryTransformationsWithoutForecastPermutationsTest.java
+++ b/src/test/java/com/axibase/tsd/api/method/series/SeriesQueryTransformationsWithoutForecastPermutationsTest.java
@@ -177,13 +177,13 @@ public class SeriesQueryTransformationsWithoutForecastPermutationsTest extends S
 
 
     @Test(dataProvider = "permutations",
-
-            description = "Take series transformations {@link Transformation#values()} except for {@link Transformation#FORECAST}. " +
-                        "Create query which has these transformations. " +
-                        "Check that response contains correct number of generated series for each permutation of the transformations.")
+            description = "Take series transformations {@link Transformation#values()} except for " +
+                    "{@link Transformation#FORECAST}. Create query which has these transformations. " +
+                    "Check that response contains correct number of generated series " +
+                    "for each permutation of the transformations.")
     public void test(List<Transformation> permutation) {
-        query.setTransformationOrder(permutation);
-        List<Series> seriesList = querySeriesAsList(query);
+        SeriesQuery testQuery = query.withTransformationOrder(permutation);
+        List<Series> seriesList = querySeriesAsList(testQuery);
         int expectedSeriesCount = countExpectedSeries(permutation);
         assertEquals(seriesList.size(), expectedSeriesCount);
     }


### PR DESCRIPTION
Fix SeriesQueryTransformationsWithoutForecastPermutationsTest test.
Parallel testing threads modify and test the same query object.
Fix that by cloning query for each test case.