### PR TITLE
Additional check that response is a valid json string. More test cases for trade API queries.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,6 +74,12 @@
             <version>1.3.0</version>
         </dependency>
 
+        <dependency>
+            <groupId>com.googlecode.json-simple</groupId>
+            <artifactId>json-simple</artifactId>
+            <version>1.1.1</version>
+        </dependency>
+
         <!--html parsing-->
         <dependency>
             <groupId>org.jsoup</groupId>

--- a/src/main/java/com/axibase/tsd/api/util/JsonParsingException.java
+++ b/src/main/java/com/axibase/tsd/api/util/JsonParsingException.java
@@ -1,0 +1,7 @@
+package com.axibase.tsd.api.util;
+
+public class JsonParsingException extends RuntimeException {
+    public JsonParsingException(String message) {
+        super(message);
+    }
+}

--- a/src/test/java/com/axibase/tsd/api/method/series/trade/TradeSideTest.java
+++ b/src/test/java/com/axibase/tsd/api/method/series/trade/TradeSideTest.java
@@ -28,8 +28,7 @@ import java.util.concurrent.TimeUnit;
 import static com.axibase.tsd.api.model.TimeUnit.HOUR;
 import static com.axibase.tsd.api.model.TimeUnit.MINUTE;
 import static com.axibase.tsd.api.util.Util.getUnixTime;
-import static org.testng.AssertJUnit.assertEquals;
-import static org.testng.AssertJUnit.assertTrue;
+import static org.testng.AssertJUnit.*;
 
 /**
  * Test that the response contains series with requested sides.
@@ -60,31 +59,42 @@ public class TradeSideTest {
     public void test(TestCase testCase) {
         List<Series> response = SeriesMethod.querySeriesAsList(testCase.query);
         assertEquals("Response has unexpected series count", testCase.seriesCount(), response.size());
-        for (Series series : response) {
-            check(series, testCase.buyPrices, testCase.sellPrices);
-        }
+        response.forEach(series -> check(series, testCase));
     }
 
-    private void check(Series series, @Nullable BigDecimal[] expectedBuyPrices, @Nullable BigDecimal[] expectedSellPrices) {
+    private void check(Series series, TestCase testCase) {
+        if (testCase.isNoDataFoundResponse()) {
+            assertTrue("It is expected that response contains an empty 'data' array.", series.getData().isEmpty());
+            assertSide(testCase.side(), series.getTags());
+            return;
+        }
         Map<String, String> tags = series.getTags();
-        assertTrue(tags.containsKey("side"));
+        assertTrue("The 'side' tag is expected in series response.", tags.containsKey("side"));
         String side = tags.get("side");
         switch (side) {
             case "B":
-                if (expectedBuyPrices == null) {
+                if (testCase.hasNoBuyPrices()) {
                     Assert.fail("Unexpected series with side tag 'B' in response");
                 }
-                assertSamePrices(series.getData(), expectedBuyPrices);
+                assertSamePrices(series.getData(), testCase.buyPrices);
                 break;
             case "S":
-                if (expectedSellPrices == null) {
+                if (testCase.hasNoSellPrices()) {
                     Assert.fail("Unexpected series with side tag 'S' in response");
                 }
-                assertSamePrices(series.getData(), expectedSellPrices);
+                assertSamePrices(series.getData(), testCase.sellPrices);
                 break;
             default:
                 Assert.fail("Not expected side tag in response: " + side);
         }
+    }
+
+    private void assertSide(String expectedSide, Map<String, String> actualTags) {
+        if (expectedSide == null) return;
+        String message = "Expect tag 'side' = '" + expectedSide + "'";
+        assertNotNull(message, actualTags);
+        String actualSide = actualTags.get("side");
+        assertEquals(message, expectedSide, actualSide);
     }
 
     private void assertSamePrices(List<Sample> actualSeries, @NotNull BigDecimal[] expectedPrices) {
@@ -99,22 +109,42 @@ public class TradeSideTest {
 
     @DataProvider
     public Object[][] testCases() {
+        Period aMinute =  new Period(1, MINUTE);
         List<TestCase> testCases = new ArrayList<>();
-        addTestCases(testCases, new int[]{1, 3, 4, 6}, new int[]{2, 5}, null);
-        addTestCases(testCases, new int[]{3, 6}, new int[]{2, 5}, new Period(1, HOUR));
-        addTestCases(testCases, new int[]{3, 4, 6}, new int[]{2, 5}, new Period(5, MINUTE));
+        addTestCases("2020-12-01T00:00:00Z", "2020-12-02T00:00:00Z", false, null, new int[]{1, 3, 4, 6}, new int[]{2, 5}, testCases);
+        addTestCases("2020-12-01T10:57:00Z", "2020-12-01T10:59:00Z", false, null, null, new int[]{2}, testCases);
+        addTestCases("2020-12-01T10:59:00Z", "2020-12-01T11:02:00Z", false, null, new int[]{3, 4}, null, testCases);
+        addTestCases("2020-12-01T00:00:00Z", "2020-12-02T00:00:00Z", true, null, new int[]{6}, new int[]{5}, testCases);
+        addTestCases("2020-12-01T10:57:00Z", "2020-12-01T10:59:00Z", true, null, null, new int[]{2}, testCases);
+        addTestCases("2020-12-01T10:59:00Z", "2020-12-01T11:02:00Z", true, null, new int[]{4}, null, testCases);
+        addTestCases("2020-12-01T00:00:00Z", "2020-12-02T00:00:00Z", true, new Period(1, HOUR), new int[]{3, 6}, new int[]{2, 5}, testCases);
+        addTestCases("2020-12-01T00:00:00Z", "2020-12-02T00:00:00Z", true, new Period(5, MINUTE), new int[]{3, 4, 6}, new int[]{2, 5}, testCases);
+        addTestCases("2020-12-01T10:57:00Z", "2020-12-01T10:59:00Z", true, aMinute, null, new int[]{2}, testCases);
+        addTestCases("2020-12-01T10:59:00Z", "2020-12-01T11:02:00Z", true, aMinute, new int[]{3, 4}, null, testCases);
+        addTestCases("2020-12-01T11:03:00Z", "2020-12-01T11:06:00Z", false, null, null, null, testCases);
+        addTestCases("2020-12-01T11:03:00Z", "2020-12-01T11:06:00Z", true, null, null, null, testCases);
+        addTestCases("2020-12-01T11:03:00Z", "2020-12-01T11:06:00Z", false, aMinute, null, null, testCases);
         return TestUtil.convertTo2DimArray(testCases);
     }
 
-    private void addTestCases(List<TestCase> testCases, int[] buyPrices, int[] sellPrices, Period period) {
+    private void addTestCases(String startTime, String endTime, boolean setAggregation, Period period, int[] buyPrices, int[] sellPrices, List<TestCase> testCases) {
         BigDecimal[] decimalBuyPrices = toBigDecimal(buyPrices);
         BigDecimal[] decimalSellPrices = toBigDecimal(sellPrices);
-        testCases.add(new TestCase(query(period), null, decimalBuyPrices, decimalSellPrices));
-        testCases.add(new TestCase(query(period), "*", decimalBuyPrices, decimalSellPrices));
-        testCases.add(new TestCase(query(period), "B", decimalBuyPrices, null));
-        testCases.add(new TestCase(query(period), "S", null, decimalSellPrices));
+
+        SeriesQuery query = query(startTime, endTime, null, setAggregation, period);
+        testCases.add(new TestCase(query, decimalBuyPrices, decimalSellPrices));
+
+        query = query(startTime, endTime, "*", setAggregation, period);
+        testCases.add(new TestCase(query, decimalBuyPrices, decimalSellPrices));
+
+        query = query(startTime, endTime, "B", setAggregation, period);
+        testCases.add(new TestCase(query, decimalBuyPrices, null));
+
+        query = query(startTime, endTime, "S", setAggregation, period);
+        testCases.add(new TestCase(query, null, decimalSellPrices));
     }
 
+    @NotNull
     private BigDecimal[] toBigDecimal(int[] intPrices) {
         int samplesCount = intPrices == null ? 0 : intPrices.length;
         BigDecimal[] decimalPrices = new BigDecimal[samplesCount];
@@ -124,11 +154,16 @@ public class TradeSideTest {
         return decimalPrices;
     }
 
-    private SeriesQuery query(@Nullable Period period) {
-        String startDate = "2020-12-01T00:00:00Z";
-        String endDate = "2020-12-02T00:00:00Z";
-        SeriesQuery query = new SeriesQuery(entity, metric, startDate, endDate);
-        if (period != null) {
+    private SeriesQuery query(String startTime,
+                              String endTime,
+                              @Nullable String side,
+                              boolean setAggregation,
+                              @Nullable Period period) {
+        SeriesQuery query = new SeriesQuery(entity, metric, startTime, endTime);
+        if (side != null) {
+            query.addTag("side", side);
+        }
+        if (setAggregation) {
             query.setAggregate(new Aggregate(AggregationType.LAST, period));
         }
         return query;
@@ -136,20 +171,44 @@ public class TradeSideTest {
 
     private static class TestCase {
         private final SeriesQuery query;
+        @NotNull
         private final BigDecimal[] buyPrices;
+        @NotNull
         private final BigDecimal[] sellPrices;
 
-        public TestCase(SeriesQuery query, String side, BigDecimal[] buyPrices, BigDecimal[] sellPrices) {
-            if (side != null) {
-                query.addTag("side", side);
-            }
+        public TestCase(SeriesQuery query, @Nullable BigDecimal[] buyPrices, @Nullable BigDecimal[] sellPrices) {
             this.query = query;
-            this.buyPrices = buyPrices;
-            this.sellPrices = sellPrices;
+            this.buyPrices = buyPrices == null ? new BigDecimal[0] : buyPrices;
+            this.sellPrices = sellPrices == null ? new BigDecimal[0] : sellPrices;
         }
 
         public int seriesCount() {
-            return (buyPrices == null && sellPrices == null) ? 0 : (buyPrices == null || sellPrices == null) ? 1 : 2;
+            return buyPrices.length == 0 || sellPrices.length == 0 ? 1 : 2;
+        }
+
+        public boolean isNoDataFoundResponse() {
+            return buyPrices.length == 0 && sellPrices.length == 0;
+        }
+
+        @Nullable
+        public String side() {
+            Map<String, String> tags = query.getTags();
+            if (tags == null) {
+                return null;
+            }
+            String side = tags.get("side");
+            if (side == null || side.equalsIgnoreCase("*")) {
+                return null;
+            }
+            return side;
+        }
+
+        public boolean hasNoBuyPrices() {
+            return buyPrices.length == 0;
+        }
+
+        public boolean hasNoSellPrices() {
+            return sellPrices.length == 0;
         }
     }
 


### PR DESCRIPTION
More careful check that response is a valid json string. Additional tests for trade API queries with different required sides.

ATSD may send something like the following in response to API series query:
```
[{"metric":"cpu_usage"}]DATA_API_SERIES_QUERY_PROCESSING_ERRORcom.axibase.Class: Exception
```
That happence if ATSD produces an exception after response was partially written.
Current tests do not notice what json is broken and just ignore
the `DATA_API_SERIES_QUERY_PROCESSING_ERRORcom.axibase.Class: Exception` string.
So I've added another json parsing library and additional check that json is well-formed.
Some of tests started to fail after this additional check, due to unnoticed bug in ATSD,
which is fixed in https://github.com/axibase/tsd/pull/1015 (not merged in the master).