### PR TITLE
API message tests: check that message entity is created before check the message itself.

### DIFF
--- a/src/main/java/com/axibase/tsd/api/method/checks/Check.java
+++ b/src/main/java/com/axibase/tsd/api/method/checks/Check.java
@@ -1,0 +1,26 @@
+package com.axibase.tsd.api.method.checks;
+
+
+import lombok.RequiredArgsConstructor;
+
+import java.util.function.Supplier;
+
+@RequiredArgsConstructor
+public class Check extends AbstractCheck {
+    private final String errorMessage;
+    private final Supplier<Boolean> checker;
+
+    @Override
+    public boolean isChecked() {
+        try {
+            return checker.get();
+        } catch (Exception e) {
+            throw new IllegalStateException(errorMessage, e);
+        }
+    }
+
+    @Override
+    public String getErrorMessage() {
+        return errorMessage;
+    }
+}

--- a/src/test/java/com/axibase/tsd/api/method/message/MessageTest.java
+++ b/src/test/java/com/axibase/tsd/api/method/message/MessageTest.java
@@ -3,7 +3,9 @@ package com.axibase.tsd.api.method.message;
 
 import com.axibase.tsd.api.Checker;
 import com.axibase.tsd.api.method.checks.AbstractCheck;
+import com.axibase.tsd.api.method.checks.Check;
 import com.axibase.tsd.api.method.checks.MessageCheck;
+import com.axibase.tsd.api.method.entity.EntityMethod;
 import com.axibase.tsd.api.model.message.Message;
 import com.axibase.tsd.api.model.message.MessageQuery;
 import com.axibase.tsd.api.util.NotCheckedException;
@@ -16,22 +18,49 @@ import java.util.List;
 import static org.testng.AssertJUnit.fail;
 
 public class MessageTest extends MessageMethod {
-    public static void assertMessageExisting(String assertMessage, Message message) {
-        try {
-            Checker.check(new MessageCheck(message));
-        } catch (NotCheckedException e) {
-            fail(assertMessage);
-        }
-    }
 
     public static void assertMessageExisting(Message message) {
         String assertMessage = String.format(
                 DefaultMessagesTemplates.MESSAGE_NOT_EXIST,
                 message
         );
-        assertMessageExisting(assertMessage, message);
+        assertMessageExisting(assertMessage, message, true);
     }
 
+    public static void assertMessageExisting(String assertMessage, Message message) {
+        assertMessageExisting(assertMessage, message, true);
+    }
+
+    /**
+     * @param checkThatMessageEntityIsCreated If true, then get entity name from the {@param message},
+     *                                 and check that ATSD has entity with this name
+     *                                 before check the message itself.
+     */
+    public static void assertMessageExisting(String assertMessage, Message message, boolean checkThatMessageEntityIsCreated) {
+        if (checkThatMessageEntityIsCreated) {
+            assertEntity(message.getEntity());
+        }
+        assertMessage(assertMessage, message);
+    }
+
+    private static void assertEntity(String entityName) {
+        System.out.println("Assert entity called!");
+        String errorMessage = String.format("ATSD dos not know entity %s.", entityName);
+        Check entityNameCheck = new Check(errorMessage, () -> EntityMethod.entityExist(entityName));
+        try {
+            Checker.check(entityNameCheck);
+        } catch (NotCheckedException e) {
+            fail(errorMessage);
+        }
+    }
+
+    private static void assertMessage(String assertMessage, Message message) {
+        try {
+            Checker.check(new MessageCheck(message));
+        } catch (NotCheckedException e) {
+            fail(assertMessage);
+        }
+    }
 
     public static void assertMessageQuerySize(final MessageQuery query, final Integer size) {
         try {

--- a/src/test/java/com/axibase/tsd/api/method/message/MessageTest.java
+++ b/src/test/java/com/axibase/tsd/api/method/message/MessageTest.java
@@ -44,7 +44,6 @@ public class MessageTest extends MessageMethod {
     }
 
     private static void assertEntity(String entityName) {
-        System.out.println("Assert entity called!");
         String errorMessage = String.format("ATSD dos not know entity %s.", entityName);
         Check entityNameCheck = new Check(errorMessage, () -> EntityMethod.entityExist(entityName));
         try {

--- a/src/test/java/com/axibase/tsd/api/method/message/MessageTest.java
+++ b/src/test/java/com/axibase/tsd/api/method/message/MessageTest.java
@@ -44,7 +44,7 @@ public class MessageTest extends MessageMethod {
     }
 
     private static void assertEntity(String entityName) {
-        String errorMessage = String.format("ATSD dos not know entity %s.", entityName);
+        String errorMessage = String.format("ATSD does not know entity %s.", entityName);
         Check entityNameCheck = new Check(errorMessage, () -> EntityMethod.entityExist(entityName));
         try {
             Checker.check(entityNameCheck);


### PR DESCRIPTION
In the message tests, we usually insert a message and then query it.
Based on the response code we may repeat the query, in order to get ATSD more time
to process the message. The response code is not a too reliable way to determine that the message is still not processed by ATSD. (I have changed message processing, ATSD starts to return another code during message processing time, and tests fail.)
This PR should mitigate this issue in the case when the message has a unique entity, and ATSD needs time to create the entity. In this case, we may (optionally) check that entity was created before checking the message itself.