### PR TITLE
Support multiple values for a tag in series query.

### DIFF
--- a/src/main/java/com/axibase/tsd/api/model/Period.java
+++ b/src/main/java/com/axibase/tsd/api/model/Period.java
@@ -34,7 +34,7 @@ public class Period {
     }
 
     /**
-     * Create a Period object with count, unit, and timezone fields.
+     * Create a Period object with count, unit, and alignment.
      *
      * @param count           an amount of time units.
      * @param unit            {@link TimeUnit} instance.

--- a/src/main/java/com/axibase/tsd/api/model/series/query/SeriesQuery.java
+++ b/src/main/java/com/axibase/tsd/api/model/series/query/SeriesQuery.java
@@ -24,6 +24,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import static com.axibase.tsd.api.util.Util.MAX_QUERYABLE_DATE;
 import static com.axibase.tsd.api.util.Util.MIN_QUERYABLE_DATE;
@@ -75,10 +76,8 @@ public class SeriesQuery {
     public SeriesQuery(Series series) {
         entity = escapeExpression(series.getEntity());
         metric = series.getMetric();
-        tags = new HashMap<>();
-        for (Map.Entry<String, String> keyValue : series.getTags().entrySet()) {
-            tags.put(keyValue.getKey(), Util.wrapInList(escapeExpression(keyValue.getValue())));
-        }
+        tags = series.getTags().entrySet().stream().collect(
+                Collectors.toMap(Map.Entry::getKey, entry -> Util.wrapInMutableList(escapeExpression(entry.getValue()))));
         exactMatch = true;
         if (series.getData().isEmpty()) {
             startDate = MIN_QUERYABLE_DATE;
@@ -107,7 +106,8 @@ public class SeriesQuery {
         this.metric = metric;
         this.startDate = startDate;
         this.endDate = endDate;
-        this.tags = Util.wrapValuesInLists(tags);
+        this.tags = tags.entrySet().stream()
+                .collect(Collectors.toMap(Map.Entry::getKey, entry -> Util.wrapInMutableList(entry.getValue())));
     }
 
     private String escapeExpression(String expression) {

--- a/src/main/java/com/axibase/tsd/api/util/Util.java
+++ b/src/main/java/com/axibase/tsd/api/util/Util.java
@@ -106,14 +106,7 @@ public class Util {
         return map.entrySet().stream().collect(Collectors.toMap(x -> x.getKey(), x -> x.getValue()));
     }
 
-    /** Wrap each value of provided map into list. */
-    public static Map<String, List<String>> wrapValuesInLists(Map<String, String> map) {
-        return map.entrySet().stream().collect(
-                Collectors.toMap(Map.Entry::getKey, entry -> wrapInList(entry.getValue()))
-        );
-    }
-
-    public static ArrayList<String> wrapInList(String value) {
+    public static ArrayList<String> wrapInMutableList(String value) {
         ArrayList<String> list = new ArrayList<>(1);
         list.add(value);
         return list;

--- a/src/main/java/com/axibase/tsd/api/util/Util.java
+++ b/src/main/java/com/axibase/tsd/api/util/Util.java
@@ -13,10 +13,7 @@ import javax.ws.rs.core.Form;
 import javax.ws.rs.core.Response;
 import java.nio.charset.StandardCharsets;
 import java.time.*;
-import java.util.Date;
-import java.util.List;
-import java.util.Map;
-import java.util.TimeZone;
+import java.util.*;
 import java.util.stream.Collectors;
 
 
@@ -107,6 +104,19 @@ public class Util {
 
     public static Map<String, Object> toStringObjectMap(Map<String, String> map) {
         return map.entrySet().stream().collect(Collectors.toMap(x -> x.getKey(), x -> x.getValue()));
+    }
+
+    /** Wrap each value of provided map into list. */
+    public static Map<String, List<String>> wrapValuesInLists(Map<String, String> map) {
+        return map.entrySet().stream().collect(
+                Collectors.toMap(Map.Entry::getKey, entry -> wrapInList(entry.getValue()))
+        );
+    }
+
+    public static ArrayList<String> wrapInList(String value) {
+        ArrayList<String> list = new ArrayList<>(1);
+        list.add(value);
+        return list;
     }
 
     private static final class AtsdVersionInfo {

--- a/src/test/java/com/axibase/tsd/api/method/financial/InstrumentSearchBase.java
+++ b/src/test/java/com/axibase/tsd/api/method/financial/InstrumentSearchBase.java
@@ -123,7 +123,7 @@ public class InstrumentSearchBase {
                     .limit(1)
                     .map(entry -> new SeriesQuery(makeEntityName(entry.getSymbol(), entry.getClassCode()), TRADE_PRICE_METRIC,
                             IndicesGenerator.startTime, IndicesGenerator.timestamp.get() + 1)
-                        .setTags(Collections.singletonMap("exchange", entry.getExchange())))
+                        .addTag("exchange", entry.getExchange()))
                     .map(query -> new SeriesQueryDataSizeCheck(query, 1))
                     .forEach(check -> Checker.check(check, time, timeUnit));
             updateInstrumentIndex();

--- a/src/test/java/com/axibase/tsd/api/method/series/SeriesQueryForecastAutoAggregateTest.java
+++ b/src/test/java/com/axibase/tsd/api/method/series/SeriesQueryForecastAutoAggregateTest.java
@@ -27,7 +27,7 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertSame;
 
 /**
- * Test of auto aggregation. Applied if flag {@link Forecast#autoAggregate} is true.
+ * Test of auto aggregation.
  * Check that response contains correct forecast series.
  *
  * Method insertSeries() create input series.

--- a/src/test/java/com/axibase/tsd/api/method/series/SeriesQueryReadStoredForecastTest.java
+++ b/src/test/java/com/axibase/tsd/api/method/series/SeriesQueryReadStoredForecastTest.java
@@ -6,6 +6,7 @@ import com.axibase.tsd.api.model.series.Series;
 import com.axibase.tsd.api.model.series.SeriesType;
 import com.axibase.tsd.api.model.series.query.SeriesQuery;
 import com.axibase.tsd.api.util.Mocks;
+import com.axibase.tsd.api.util.Util;
 import com.google.common.collect.ImmutableMap;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
@@ -70,54 +71,54 @@ public class SeriesQueryReadStoredForecastTest extends SeriesMethod {
                 {ImmutableMap.of(), true, new Series[]{SERIES_1}},
                 {ImmutableMap.of(), false, new Series[]{SERIES_1, SERIES_2, SERIES_3, SERIES_4, SERIES_5, SERIES_6, SERIES_7, SERIES_8, SERIES_9}},
 
-                {ImmutableMap.of(TAG_NAME_1, TAG_VALUE_1), true, new Series[]{SERIES_2}},
-                {ImmutableMap.of(TAG_NAME_1, TAG_VALUE_1), false, new Series[]{SERIES_2, SERIES_6, SERIES_8}},
+                {tags(TAG_NAME_1, TAG_VALUE_1), true, new Series[]{SERIES_2}},
+                {tags(TAG_NAME_1, TAG_VALUE_1), false, new Series[]{SERIES_2, SERIES_6, SERIES_8}},
 
-                {ImmutableMap.of(TAG_NAME_1, TAG_VALUE_2), true, new Series[]{SERIES_3}},
-                {ImmutableMap.of(TAG_NAME_1, TAG_VALUE_2), false, new Series[]{SERIES_3, SERIES_7, SERIES_9}},
+                {tags(TAG_NAME_1, TAG_VALUE_2), true, new Series[]{SERIES_3}},
+                {tags(TAG_NAME_1, TAG_VALUE_2), false, new Series[]{SERIES_3, SERIES_7, SERIES_9}},
 
-                {ImmutableMap.of(TAG_NAME_1, "*"), true, new Series[]{SERIES_2, SERIES_3}},
-                {ImmutableMap.of(TAG_NAME_1, "*"), false, new Series[]{SERIES_2, SERIES_3, SERIES_6, SERIES_7, SERIES_8, SERIES_9}},
+                {tags(TAG_NAME_1, "*"), true, new Series[]{SERIES_2, SERIES_3}},
+                {tags(TAG_NAME_1, "*"), false, new Series[]{SERIES_2, SERIES_3, SERIES_6, SERIES_7, SERIES_8, SERIES_9}},
 
-                {ImmutableMap.of(TAG_NAME_2, TAG_VALUE_1), true, new Series[]{SERIES_4}},
-                {ImmutableMap.of(TAG_NAME_2, TAG_VALUE_1), false, new Series[]{SERIES_4, SERIES_7, SERIES_8}},
+                {tags(TAG_NAME_2, TAG_VALUE_1), true, new Series[]{SERIES_4}},
+                {tags(TAG_NAME_2, TAG_VALUE_1), false, new Series[]{SERIES_4, SERIES_7, SERIES_8}},
 
-                {ImmutableMap.of(TAG_NAME_2, TAG_VALUE_2), true, new Series[]{SERIES_5}},
-                {ImmutableMap.of(TAG_NAME_2, TAG_VALUE_2), false, new Series[]{SERIES_5, SERIES_6, SERIES_9}},
+                {tags(TAG_NAME_2, TAG_VALUE_2), true, new Series[]{SERIES_5}},
+                {tags(TAG_NAME_2, TAG_VALUE_2), false, new Series[]{SERIES_5, SERIES_6, SERIES_9}},
 
-                {ImmutableMap.of(TAG_NAME_2, "*"), true, new Series[]{SERIES_4, SERIES_5}},
-                {ImmutableMap.of(TAG_NAME_2, "*"), false, new Series[]{SERIES_4, SERIES_5, SERIES_6, SERIES_7, SERIES_8, SERIES_9}},
+                {tags(TAG_NAME_2, "*"), true, new Series[]{SERIES_4, SERIES_5}},
+                {tags(TAG_NAME_2, "*"), false, new Series[]{SERIES_4, SERIES_5, SERIES_6, SERIES_7, SERIES_8, SERIES_9}},
 
-                {ImmutableMap.of(TAG_NAME_1, TAG_VALUE_1, TAG_NAME_2, TAG_VALUE_2), true, new Series[]{SERIES_6}},
-                {ImmutableMap.of(TAG_NAME_1, TAG_VALUE_1, TAG_NAME_2, TAG_VALUE_2), false, new Series[]{SERIES_6}},
+                {tags(TAG_NAME_1, TAG_VALUE_1, TAG_NAME_2, TAG_VALUE_2), true, new Series[]{SERIES_6}},
+                {tags(TAG_NAME_1, TAG_VALUE_1, TAG_NAME_2, TAG_VALUE_2), false, new Series[]{SERIES_6}},
 
-                {ImmutableMap.of(TAG_NAME_1, TAG_VALUE_1, TAG_NAME_2, TAG_VALUE_1), true, new Series[]{SERIES_8}},
-                {ImmutableMap.of(TAG_NAME_1, TAG_VALUE_1, TAG_NAME_2, TAG_VALUE_1), false, new Series[]{SERIES_8}},
+                {tags(TAG_NAME_1, TAG_VALUE_1, TAG_NAME_2, TAG_VALUE_1), true, new Series[]{SERIES_8}},
+                {tags(TAG_NAME_1, TAG_VALUE_1, TAG_NAME_2, TAG_VALUE_1), false, new Series[]{SERIES_8}},
 
-                {ImmutableMap.of(TAG_NAME_1, "*", TAG_NAME_2, TAG_VALUE_1), true, new Series[]{SERIES_7, SERIES_8}},
-                {ImmutableMap.of(TAG_NAME_1, "*", TAG_NAME_2, TAG_VALUE_1), false, new Series[]{SERIES_7, SERIES_8}},
+                {tags(TAG_NAME_1, "*", TAG_NAME_2, TAG_VALUE_1), true, new Series[]{SERIES_7, SERIES_8}},
+                {tags(TAG_NAME_1, "*", TAG_NAME_2, TAG_VALUE_1), false, new Series[]{SERIES_7, SERIES_8}},
 
-                {ImmutableMap.of(TAG_NAME_1, "*", TAG_NAME_2, "*"), true, new Series[]{SERIES_6, SERIES_7, SERIES_8, SERIES_9}},
-                {ImmutableMap.of(TAG_NAME_1, "*", TAG_NAME_2, "*"), false, new Series[]{SERIES_6, SERIES_7, SERIES_8, SERIES_9}},
+                {tags(TAG_NAME_1, "*", TAG_NAME_2, "*"), true, new Series[]{SERIES_6, SERIES_7, SERIES_8, SERIES_9}},
+                {tags(TAG_NAME_1, "*", TAG_NAME_2, "*"), false, new Series[]{SERIES_6, SERIES_7, SERIES_8, SERIES_9}},
 
-                {ImmutableMap.of(TAG_NAME_1, TAG_VALUE_1, TAG_NAME_2, "*"), true, new Series[]{SERIES_6, SERIES_8}},
-                {ImmutableMap.of(TAG_NAME_1, TAG_VALUE_2, TAG_NAME_2, TAG_VALUE_1), true, new Series[]{SERIES_7}},
-                {ImmutableMap.of(TAG_NAME_1, TAG_VALUE_2, TAG_NAME_2, TAG_VALUE_2), true, new Series[]{SERIES_9}},
-                {ImmutableMap.of(TAG_NAME_1, TAG_VALUE_2, TAG_NAME_2, "*"), true, new Series[]{SERIES_7, SERIES_9}},
-                {ImmutableMap.of(TAG_NAME_1, "*", TAG_NAME_2, TAG_VALUE_2), true, new Series[]{SERIES_6, SERIES_9}},
+                {tags(TAG_NAME_1, TAG_VALUE_1, TAG_NAME_2, "*"), true, new Series[]{SERIES_6, SERIES_8}},
+                {tags(TAG_NAME_1, TAG_VALUE_2, TAG_NAME_2, TAG_VALUE_1), true, new Series[]{SERIES_7}},
+                {tags(TAG_NAME_1, TAG_VALUE_2, TAG_NAME_2, TAG_VALUE_2), true, new Series[]{SERIES_9}},
+                {tags(TAG_NAME_1, TAG_VALUE_2, TAG_NAME_2, "*"), true, new Series[]{SERIES_7, SERIES_9}},
+                {tags(TAG_NAME_1, "*", TAG_NAME_2, TAG_VALUE_2), true, new Series[]{SERIES_6, SERIES_9}},
         };
     }
 
     @DataProvider(name = "series_and_empty_expected_data", parallel = true)
     Object[][] seriesAndEmptyExpectedData() {
         return new Object[][]{
-                {ImmutableMap.of(TAG_NAME_1, TAG_VALUE_1 + TAG_VALUE_2), true},
-                {ImmutableMap.of(TAG_NAME_1, TAG_VALUE_1 + TAG_VALUE_2), false}
+                {tags(TAG_NAME_1, TAG_VALUE_1 + TAG_VALUE_2), true},
+                {tags(TAG_NAME_1, TAG_VALUE_1 + TAG_VALUE_2), false}
         };
     }
 
     @Test(dataProvider = "settings_and_expected_series_data", description = "Check that series in response is matched to requested")
-    public void testSeriesIsMatchRequested(Map<String, String> queryTags, boolean exactMatch, Series[] expectedSeries) {
+    public void testSeriesIsMatchRequested(Map<String, List<String>> queryTags, boolean exactMatch, Series[] expectedSeries) {
         SeriesQuery query = QUERY
                 .withTags(queryTags)
                 .withExactMatch(exactMatch);
@@ -126,7 +127,7 @@ public class SeriesQueryReadStoredForecastTest extends SeriesMethod {
     }
 
     @Test(dataProvider = "series_and_empty_expected_data", description = "Check that series in response is matched to requested empty")
-    public void testSeriesMatchedToEmpty(Map<String, String> queryTags, boolean exactMatch) {
+    public void testSeriesMatchedToEmpty(Map<String, List<String>> queryTags, boolean exactMatch) {
         SeriesQuery query = QUERY
                 .withTags(queryTags)
                 .withExactMatch(exactMatch);
@@ -140,5 +141,13 @@ public class SeriesQueryReadStoredForecastTest extends SeriesMethod {
      */
     private Object[] getTags(List<Series> seriesList) {
         return seriesList.stream().map(Series::getTags).toArray();
+    }
+
+    Map<String, List<String>> tags(String k1, String v1) {
+        return ImmutableMap.of(k1, Util.wrapInList(v1));
+    }
+
+    Map<String, List<String>> tags(String k1, String v1, String k2, String v2) {
+        return ImmutableMap.of(k1, Util.wrapInList(v1), k2, Util.wrapInList(v2));
     }
 }

--- a/src/test/java/com/axibase/tsd/api/method/series/SeriesQueryReadStoredForecastTest.java
+++ b/src/test/java/com/axibase/tsd/api/method/series/SeriesQueryReadStoredForecastTest.java
@@ -144,10 +144,10 @@ public class SeriesQueryReadStoredForecastTest extends SeriesMethod {
     }
 
     Map<String, List<String>> tags(String k1, String v1) {
-        return ImmutableMap.of(k1, Util.wrapInList(v1));
+        return ImmutableMap.of(k1, Util.wrapInMutableList(v1));
     }
 
     Map<String, List<String>> tags(String k1, String v1, String k2, String v2) {
-        return ImmutableMap.of(k1, Util.wrapInList(v1), k2, Util.wrapInList(v2));
+        return ImmutableMap.of(k1, Util.wrapInMutableList(v1), k2, Util.wrapInMutableList(v2));
     }
 }

--- a/src/test/java/com/axibase/tsd/api/method/series/SeriesQueryTagExpressionFilterTest.java
+++ b/src/test/java/com/axibase/tsd/api/method/series/SeriesQueryTagExpressionFilterTest.java
@@ -162,10 +162,10 @@ public class SeriesQueryTagExpressionFilterTest extends SeriesMethod {
                 if (!tagValue.equals("null")) {
                     expectedTagsSet.add(tagValue);
                 }
-                query.setTags(Collections.singletonMap("tag", firstValue.get()));
+                query.addTag("tag", firstValue.get());
             }
         } else {
-            query.setTags(Collections.singletonMap("tag", "value1"));
+            query.addTag("tag", "value1");
         }
         query.setTagExpression(filter.getExpression());
         Set<String> actualTagsSet = executeTagsQuery(query);

--- a/src/test/java/com/axibase/tsd/api/method/series/SeriesQueryWildcardTest.java
+++ b/src/test/java/com/axibase/tsd/api/method/series/SeriesQueryWildcardTest.java
@@ -200,9 +200,7 @@ public class SeriesQueryWildcardTest extends SeriesMethod {
     }
 
     private List<Series> requestSeriesWithTags(SeriesQuery seriesQuery, final String key, final String value) throws Exception {
-        seriesQuery.setTags(Collections.unmodifiableMap(new HashMap<String, String>() {{
-            put(key, value);
-        }}));
+        seriesQuery.addTag(key, value);
         return querySeriesAsList(seriesQuery);
     }
 }

--- a/src/test/java/com/axibase/tsd/api/method/series/trade/SyntheticDataProvider.java
+++ b/src/test/java/com/axibase/tsd/api/method/series/trade/SyntheticDataProvider.java
@@ -76,7 +76,7 @@ public class SyntheticDataProvider {
 
     public SeriesQuery aggregateQuery(Aggregate aggregate) {
         List<String> entities = Arrays.asList(this.entities);
-        Map<String, String> tags = new HashMap<>();
+        Map<String, List<String>> tags = new HashMap<>();
         return new SeriesQuery()
                 .setMetric(metric)
                 .setEntities(entities)
@@ -88,7 +88,7 @@ public class SyntheticDataProvider {
     }
 
     public SeriesQuery entityAQuery(Group group, Aggregate aggregate) {
-        Map<String, String> tags = new HashMap<>();
+        Map<String, List<String>> tags = new HashMap<>();
         return new SeriesQuery()
                 .setMetric(metric)
                 .setEntity(entityA)

--- a/src/test/java/com/axibase/tsd/api/method/series/trade/TradeSideTest.java
+++ b/src/test/java/com/axibase/tsd/api/method/series/trade/TradeSideTest.java
@@ -192,15 +192,19 @@ public class TradeSideTest {
 
         @Nullable
         public String side() {
-            Map<String, String> tags = query.getTags();
+            Map<String, List<String>> tags = query.getTags();
             if (tags == null) {
                 return null;
             }
-            String side = tags.get("side");
-            if (side == null || side.equalsIgnoreCase("*")) {
+            List<String> sides = tags.get("side");
+            if (sides == null || sides.isEmpty()) {
                 return null;
             }
-            return side;
+            if (sides.size() > 1) {
+                throw new IllegalArgumentException("A query in this test can not have more than one side.");
+            }
+            String side = sides.get(0);
+            return side.equalsIgnoreCase("*") ? null : side;
         }
 
         public boolean hasNoBuyPrices() {


### PR DESCRIPTION
Change `SeriesQuery.tags` type from `Map<String, String>` to `Map<String, List<String>>` to allow multiple values for a tag in API series query.