### PR TITLE
Test trade API series query with "detail" group type.

### DIFF
--- a/src/main/java/com/axibase/tsd/api/model/financial/Trade.java
+++ b/src/main/java/com/axibase/tsd/api/model/financial/Trade.java
@@ -22,8 +22,14 @@ public class Trade {
     public enum Session {S, N, L, E, O}
 
     private long number;
-    private long timestamp;     // trade time in microseconds truncated to milliseconds = trade time with last 3 digits removed
-    private long microSeconds;  // (trade time in microseconds - timestamp * 1000) = last 3 digits of trade time
+    /**
+     * Trade time is measured in microseconds.
+     * Trade time = timestamp * 1000 + microSeconds.
+     * timestamp = trade time / 1000 = count of milliseconds in the trade time.
+     * microSeconds = trade time - timestamp * 1000 = last 3 digits of trade time.
+     */
+    private long timestamp;
+    private long microSeconds;
     private String clazz;
     private String symbol;
     private String exchange;
@@ -79,5 +85,10 @@ public class Trade {
         return Stream.of(number, timestamp, microSeconds, clazz, symbol, exchange, csvSide, quantity, price, order, session)
                 .map(n -> n == null ? "" : n.toString())
                 .collect(Collectors.joining(","));
+    }
+
+    /** @return Trade timestamp measured in nanoseconds. */
+    public long epochNano() {
+        return (timestamp * 1000 + microSeconds) * 1000;
     }
 }

--- a/src/test/java/com/axibase/tsd/api/util/TimeUtil.java
+++ b/src/test/java/com/axibase/tsd/api/util/TimeUtil.java
@@ -1,0 +1,11 @@
+package com.axibase.tsd.api.util;
+
+import java.time.ZonedDateTime;
+
+public class TimeUtil {
+
+    public static long epochNano(String isoTime) {
+        ZonedDateTime time = ZonedDateTime.parse(isoTime);
+        return time.toEpochSecond() * 1_000_000_000L + time.getNano();
+    }
+}


### PR DESCRIPTION
Implement method `GroupingTest.testDetailGrouping()` which tests a query similar with:
```
[{
    "entity": "aaa_[bbb]",
    "metric": "trade_price",
    "group": {"type": "DETAIL"},
    "startDate": "2021-02-25T07:09:55.000Z",
    "endDate": "2021-02-25T07:10:00.000Z",
    "timeFormat": "iso"
}]
```
