### PR TITLE
Test ForecastSettings.TimeFilter.

### DIFF
--- a/src/main/java/com/axibase/tsd/api/model/series/Series.java
+++ b/src/main/java/com/axibase/tsd/api/model/series/Series.java
@@ -149,6 +149,14 @@ public class Series implements Comparable<Series> {
         return this;
     }
 
+    public Series addSample(Sample sample) {
+        if (data == null) {
+            data = new ArrayList<>();
+        }
+        data.add(sample);
+        return this;
+    }
+
     public Series addSamples(final List<Sample> samples) {
         if (data == null) {
             data = samples;

--- a/src/main/java/com/axibase/tsd/api/model/series/query/SeriesQuery.java
+++ b/src/main/java/com/axibase/tsd/api/model/series/query/SeriesQuery.java
@@ -20,10 +20,7 @@ import lombok.Data;
 import lombok.experimental.Accessors;
 import lombok.experimental.Wither;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.stream.Collectors;
 
 import static com.axibase.tsd.api.util.Util.MAX_QUERYABLE_DATE;
@@ -69,6 +66,7 @@ public class SeriesQuery {
     private List<Transformation> transformationOrder;
     private String minInsertDate;
     private String maxInsertDate;
+    private TimeZone timezone;
 
     public SeriesQuery() {
     }

--- a/src/main/java/com/axibase/tsd/api/model/series/query/transformation/forecast/Forecast.java
+++ b/src/main/java/com/axibase/tsd/api/model/series/query/transformation/forecast/Forecast.java
@@ -31,6 +31,13 @@ public class Forecast {
     /** Optional. Include input series, forecast, and reconstructed series into response? Default - include forecast. */
     private List<SeriesType> include;
 
+    /** Optional.
+     * Remove samples of input series based on their timestamps according to this schedule,
+     * calculate a sequence forecast values,
+     * assign timestamps to forecast using input series period and this schedule.
+     */
+    private TimeFilter timeFilter;
+
     /* Optional. Order in sequence of other transformations. */
     private int order = 0;
 

--- a/src/main/java/com/axibase/tsd/api/model/series/query/transformation/forecast/TimeFilter.java
+++ b/src/main/java/com/axibase/tsd/api/model/series/query/transformation/forecast/TimeFilter.java
@@ -1,0 +1,17 @@
+package com.axibase.tsd.api.model.series.query.transformation.forecast;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.experimental.Accessors;
+
+@Data
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Accessors(chain = true)
+@NoArgsConstructor
+public class TimeFilter {
+    private String from;
+    private String to;
+    private boolean workingDaysOnly;
+    private String calendar;
+}

--- a/src/main/java/com/axibase/tsd/api/model/series/query/transformation/forecast/TimeFilter.java
+++ b/src/main/java/com/axibase/tsd/api/model/series/query/transformation/forecast/TimeFilter.java
@@ -12,6 +12,5 @@ import lombok.experimental.Accessors;
 public class TimeFilter {
     private String from;
     private String to;
-    private boolean workingDaysOnly;
     private String calendar;
 }

--- a/src/test/java/com/axibase/tsd/api/method/series/SeriesQueryForecastTimeFilterTest.java
+++ b/src/test/java/com/axibase/tsd/api/method/series/SeriesQueryForecastTimeFilterTest.java
@@ -47,7 +47,7 @@ public class SeriesQueryForecastTimeFilterTest {
     @BeforeClass
     public void prepareData() throws Exception {
         insertInputSeries();
-        schedule = new TimeFilter().setFrom("10:00").setTo("18:00").setCalendar("rus");
+        schedule = new TimeFilter().setFrom("10:00").setTo("18:00");
         forecastSettings = buildForecastSettings();
         query = buildQuery();
     }
@@ -96,12 +96,8 @@ public class SeriesQueryForecastTimeFilterTest {
     @Test(dataProvider="testData")
     public void test(Horizon horizonSettings, boolean applySchedule, boolean workingDaysOnly, int expectedReconstructedLength, int expectedForecastLength) {
         forecastSettings.setHorizon(horizonSettings);
-        if (applySchedule) {
-            schedule.setWorkingDaysOnly(workingDaysOnly);
-            forecastSettings.setTimeFilter(schedule);
-        } else {
-            forecastSettings.setTimeFilter(null);
-        }
+        schedule.setCalendar(workingDaysOnly ? "rus" : null);
+        forecastSettings.setTimeFilter(applySchedule ? schedule : null);
         List<Series> seriesList = querySeriesAsList(query);
         Assert.assertEquals(seriesList.size(), 2);
         for (Series series : seriesList) {

--- a/src/test/java/com/axibase/tsd/api/method/series/SeriesQueryForecastTimeFilterTest.java
+++ b/src/test/java/com/axibase/tsd/api/method/series/SeriesQueryForecastTimeFilterTest.java
@@ -1,0 +1,145 @@
+package com.axibase.tsd.api.method.series;
+
+import com.axibase.tsd.api.model.Period;
+import com.axibase.tsd.api.model.PeriodAlignment;
+import com.axibase.tsd.api.model.TimeUnit;
+import com.axibase.tsd.api.model.series.Sample;
+import com.axibase.tsd.api.model.series.Series;
+import com.axibase.tsd.api.model.series.SeriesType;
+import com.axibase.tsd.api.model.series.query.Interval;
+import com.axibase.tsd.api.model.series.query.SeriesQuery;
+import com.axibase.tsd.api.model.series.query.transformation.AggregationInterpolate;
+import com.axibase.tsd.api.model.series.query.transformation.AggregationInterpolateType;
+import com.axibase.tsd.api.model.series.query.transformation.Transformation;
+import com.axibase.tsd.api.model.series.query.transformation.aggregate.Aggregate;
+import com.axibase.tsd.api.model.series.query.transformation.aggregate.AggregationType;
+import com.axibase.tsd.api.model.series.query.transformation.forecast.Forecast;
+import com.axibase.tsd.api.model.series.query.transformation.forecast.TimeFilter;
+import com.axibase.tsd.api.model.series.query.transformation.forecast.HoltWintersSettings;
+import com.axibase.tsd.api.model.series.query.transformation.forecast.Horizon;
+import com.axibase.tsd.api.util.TimeUtil;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.math.BigDecimal;
+import java.util.Arrays;
+import java.util.List;
+import java.util.TimeZone;
+
+import static com.axibase.tsd.api.method.series.SeriesMethod.insertSeriesCheck;
+import static com.axibase.tsd.api.method.series.SeriesMethod.querySeriesAsList;
+import static com.axibase.tsd.api.util.Mocks.entity;
+import static com.axibase.tsd.api.util.Mocks.metric;
+
+public class SeriesQueryForecastTimeFilterTest {
+    private final String entity = entity();
+    private final String metric = metric();
+    private final TimeZone timeZone = TimeZone.getTimeZone("UTC");
+    private final String inputSeriesStartTime = "2021-04-05T00:00:00Z"; // regular Monday
+    private final String inputSeriesEndTime = "2021-04-16T00:00:00Z"; // next week Friday midnight (beginning)
+    private final Period inputSeriesPeriod = new Period(1, TimeUnit.MINUTE, PeriodAlignment.START_TIME);
+    private SeriesQuery query;
+    private Forecast forecastSettings;
+    private TimeFilter schedule;
+
+    @BeforeClass
+    public void prepareData() throws Exception {
+        insertInputSeries();
+        schedule = new TimeFilter().setFrom("10:00").setTo("18:00").setCalendar("rus");
+        forecastSettings = buildForecastSettings();
+        query = buildQuery();
+    }
+
+    private void insertInputSeries() throws Exception {
+        Series series = new Series(entity, metric);
+        long time = TimeUtil.epochMillis(inputSeriesStartTime);
+        long seriesEndMillis = TimeUtil.epochMillis(inputSeriesEndTime);
+        long periodMillis = inputSeriesPeriod.toMilliseconds();
+        while (time < seriesEndMillis) {
+            series.addSample(Sample.ofTimeDecimal(time, BigDecimal.ONE));
+            time += periodMillis;
+        }
+        insertSeriesCheck(series);
+    }
+
+    @DataProvider(parallel = false)
+    public Object[][] testData() {
+        Interval days_2 = new Interval(2, TimeUnit.DAY);
+        Interval days_3 = new Interval(3, TimeUnit.DAY);
+        return new Object[][] {
+                {new Horizon().setLength(111), false, false, 10 * 24 * 60, 111},
+                {new Horizon().setLength(111), true, false, 11 * 8 * 60 - 24 * 60, 111}, // - 24*60: first period (= 1 day) of Holt-Winters reconstructed series is always zero, and not included in response
+                {new Horizon().setLength(111), true, true, 9 * 8 * 60 - 24 * 60, 111},
+                {new Horizon().setLength(2 * 24 * 60), true, true, 9 * 8 * 60 - 24 * 60, 2 * 24 * 60},
+                {new Horizon().setInterval(days_2), false, false, 10 * 24 * 60, 2 * 24 * 60},
+                {new Horizon().setInterval(days_2), true, false, 11 * 8 * 60 - 24 * 60, 2 * 8 * 60 - 1}, // -1: latest timestamp 17:59 is not included because it equals to end time of 2 day interval
+                {new Horizon().setInterval(days_2), true, true, 9 * 8 * 60 - 24 * 60, 1 * 8 * 60},
+                {new Horizon().setEndDate("2021-04-18T00:00:00Z"), false, false, 10 * 24 * 60, 2 * 24 * 60 + 1}, // +1: forecastEndTime implemented "inclusive"
+                {new Horizon().setEndDate("2021-04-18T00:00:00Z"), true, false, 11 * 8 * 60 - 24 * 60, 2 * 8 * 60},
+                {new Horizon().setEndDate("2021-04-18T00:00:00Z"), true, true, 9 * 8 * 60 - 24 * 60, 1 * 8 * 60},
+
+                {new Horizon().setStartDate("2021-04-15T00:00:00Z").setLength(111), false, false, 9 * 24 * 60, 111},
+                {new Horizon().setStartDate("2021-04-15T00:00:00Z").setLength(111), true, false, 10 * 8 * 60 - 24 * 60, 111},
+                {new Horizon().setStartDate("2021-04-15T00:00:00Z").setLength(111), true, true, 8 * 8 * 60 - 24 * 60, 111},
+                {new Horizon().setStartDate("2021-04-15T00:00:00Z").setLength(3 * 24 * 60), true, true, 8 * 8 * 60 - 24 * 60, 3 * 24 * 60},
+                {new Horizon().setStartDate("2021-04-15T00:00:00Z").setInterval(days_3), false, false, 9 * 24 * 60, 3 * 24 * 60},
+                {new Horizon().setStartDate("2021-04-15T00:00:00Z").setInterval(days_3), true, false, 10 * 8 * 60 - 24 * 60, 3 * 8 * 60 - 1},
+                {new Horizon().setStartDate("2021-04-15T00:00:00Z").setInterval(days_3), true, true, 8 * 8 * 60 - 24 * 60, 2 * 8 * 60},
+                {new Horizon().setStartDate("2021-04-15T00:00:00Z").setEndDate("2021-04-18T00:00:00Z"), false, false, 9 * 24 * 60, 3 * 24 * 60 + 1},
+                {new Horizon().setStartDate("2021-04-15T00:00:00Z").setEndDate("2021-04-18T00:00:00Z"), true, false, 10 * 8 * 60 - 24 * 60, 3 * 8 * 60},
+                {new Horizon().setStartDate("2021-04-15T00:00:00Z").setEndDate("2021-04-18T00:00:00Z"), true, true, 8 * 8 * 60 - 24 * 60, 2 * 8 * 60},
+        };
+    }
+
+    @Test(dataProvider="testData")
+    public void test(Horizon horizonSettings, boolean applySchedule, boolean workingDaysOnly, int expectedReconstructedLength, int expectedForecastLength) {
+        forecastSettings.setHorizon(horizonSettings);
+        if (applySchedule) {
+            schedule.setWorkingDaysOnly(workingDaysOnly);
+            forecastSettings.setTimeFilter(schedule);
+        } else {
+            forecastSettings.setTimeFilter(null);
+        }
+        List<Series> seriesList = querySeriesAsList(query);
+        Assert.assertEquals(seriesList.size(), 2);
+        for (Series series : seriesList) {
+            int actualSeriesLength = series.getData().size();
+            switch (series.getType()) {
+                case RECONSTRUCTED:
+                    Assert.assertEquals(actualSeriesLength, expectedReconstructedLength);
+                    break;
+                case FORECAST:
+                    Assert.assertEquals(actualSeriesLength, expectedForecastLength);
+                    break;
+                default:
+                    Assert.fail("Unexpected series type in response: " + series.getType());
+            }
+        }
+    }
+
+    private Forecast buildForecastSettings() {
+        HoltWintersSettings hwSettings = new HoltWintersSettings()
+                .setAlpha(0.5).setBeta(0.5).setGamma(0.5)
+                .setAuto(false)
+                .setPeriod(new Period(1, TimeUnit.DAY));
+        List<SeriesType> include = Arrays.asList(SeriesType.RECONSTRUCTED, SeriesType.FORECAST);
+        return new Forecast()
+                .setHw(hwSettings)
+                .setInclude(include)
+                .setScoreInterval(new Interval(1, TimeUnit.DAY));
+    }
+
+    private SeriesQuery buildQuery() {
+        Aggregate aggregate = new Aggregate()
+                .setType(AggregationType.AVG)
+                .setInterpolate(new AggregationInterpolate(AggregationInterpolateType.LINEAR, true))
+                .setPeriod(inputSeriesPeriod);
+        return new SeriesQuery(entity, metric, inputSeriesStartTime, inputSeriesEndTime)
+                .setTransformationOrder(Arrays.asList(Transformation.AGGREGATE, Transformation.FORECAST))
+                .setAggregate(aggregate)
+                .setForecast(forecastSettings)
+                .setTimezone(timeZone);
+    }
+}

--- a/src/test/java/com/axibase/tsd/api/util/TimeUtil.java
+++ b/src/test/java/com/axibase/tsd/api/util/TimeUtil.java
@@ -8,4 +8,8 @@ public class TimeUtil {
         ZonedDateTime time = ZonedDateTime.parse(isoTime);
         return time.toEpochSecond() * 1_000_000_000L + time.getNano();
     }
+
+    public static long epochMillis(String isoTime) {
+        return ZonedDateTime.parse(isoTime).toInstant().toEpochMilli();
+    }
 }


### PR DESCRIPTION
Test usage of `TimeFilter` during forecasting. The `timeFilter` setting is one of the `ForecastSettings` fields which allows filter input series samples based on their timestamps and is used to assign timestamps to a forecasted / reconstructed series.