### PR TITLE
Change error message in insert series check.

### DIFF
--- a/src/main/java/com/axibase/tsd/api/method/checks/SeriesCheck.java
+++ b/src/main/java/com/axibase/tsd/api/method/checks/SeriesCheck.java
@@ -16,16 +16,21 @@ import static com.axibase.tsd.api.method.series.SeriesMethod.querySeries;
 
 public class SeriesCheck extends AbstractCheck {
     private static final Logger LOGGER = LoggerFactory.getLogger(SeriesCheck.class);
-    private static final String ERROR_MESSAGE = "Failed to check series list insert.";
-    private List<Series> seriesList;
+    private static final String ERROR_MESSAGE_TEMPLATE =
+            "%nFailed to check that series list was correctly inserted " +
+            "[1. Series Query, 2. Expected Response, 3. Actual Response]: %n" +
+            " 1. Series Query %n%s%n 2. Expected Response %n%s%n 3. Actual Response %n%s%n";
+    private String errorMessage;
+    private final List<Series> seriesList;
 
     public SeriesCheck(List<Series> seriesList) {
         this.seriesList = seriesList;
+        this.errorMessage = "";
     }
 
     @Override
     public String getErrorMessage() {
-        return ERROR_MESSAGE;
+        return errorMessage;
     }
 
     @Override
@@ -48,6 +53,10 @@ public class SeriesCheck extends AbstractCheck {
         Response response = querySeries(seriesQueryList);
         String expected = BaseMethod.getJacksonMapper().writeValueAsString(transformedSeriesList);
         String actual = response.readEntity(String.class);
-        return compareJsonString(expected, actual);
+        boolean areEqual = compareJsonString(expected, actual);
+        if (!areEqual) {
+            errorMessage = String.format(ERROR_MESSAGE_TEMPLATE, seriesQueryList, expected, actual);
+        }
+        return areEqual;
     }
 }

--- a/src/test/java/com/axibase/tsd/api/method/series/SeriesQueryLimitTest.java
+++ b/src/test/java/com/axibase/tsd/api/method/series/SeriesQueryLimitTest.java
@@ -3,10 +3,7 @@ package com.axibase.tsd.api.method.series;
 import com.axibase.tsd.api.model.series.Sample;
 import com.axibase.tsd.api.model.series.Series;
 import com.axibase.tsd.api.model.series.query.SeriesQuery;
-import com.axibase.tsd.api.util.CommonAssertions;
-import com.axibase.tsd.api.util.Registry;
-import com.axibase.tsd.api.util.ResponseAsList;
-import com.axibase.tsd.api.util.Util;
+import com.axibase.tsd.api.util.*;
 import io.qameta.allure.Issue;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
@@ -24,8 +21,9 @@ import static org.testng.AssertJUnit.*;
 
 public class SeriesQueryLimitTest extends SeriesMethod {
 
-    private final static String DEFAULT_QUERY_LIMIT_METRIC = "series-query-limit-metric-1";
-    private final static String DEFAULT_QUERY_LIMIT_ENTITY_PREFIX = "series-query-limit-entity";
+    private final static String DEFAULT_QUERY_LIMIT_METRIC = Mocks.metric();
+    // actual entity names are: prefix0, prefix1, prefix2, ...
+    private final static String DEFAULT_QUERY_LIMIT_ENTITY_PREFIX = Mocks.entity();
     private final static int ENTITY_COUNT = 10;
     private final static int SERIES_WITH_TAGS_COUNT = 9;
     private final static int SAMPLES_COUNT = 10;


### PR DESCRIPTION
More detailed message in the case when a check of inserted test series fails - print a failed query, expected and actual responses.

Sasha, could you please, merge this.