### PR TITLE
Test that forecasts produced by a Forecast Job are correctly stored.

### DIFF
--- a/src/main/java/com/axibase/tsd/api/method/forecast/ForecastMethod.java
+++ b/src/main/java/com/axibase/tsd/api/method/forecast/ForecastMethod.java
@@ -1,0 +1,34 @@
+package com.axibase.tsd.api.method.forecast;
+
+import com.axibase.tsd.api.Config;
+import com.axibase.tsd.api.method.BaseMethod;
+import com.axibase.tsd.api.util.authorization.RequestSenderWithBasicAuthorization;
+import lombok.extern.slf4j.Slf4j;
+
+import javax.ws.rs.HttpMethod;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.Response;
+import java.util.Collections;
+
+@Slf4j
+public class ForecastMethod extends BaseMethod {
+    private final static String FORECAST_PATH = "/forecast/settings/edit.xhtml";
+
+    public static Response sendForecastFormData(final MultivaluedMap<String, String> formData) {
+        RequestSenderWithBasicAuthorization sender = new RequestSenderWithBasicAuthorization(
+                Config.getInstance().getLogin(),
+                Config.getInstance().getPassword()
+        );
+        Response response = sender.executeRootRequest(
+                FORECAST_PATH,
+                Collections.emptyMap(),
+                Collections.emptyMap(),
+                Collections.emptyMap(),
+                HttpMethod.POST,
+                Entity.form(formData)
+        );
+        response.bufferEntity();
+        return response;
+    }
+}

--- a/src/main/java/com/axibase/tsd/api/model/series/Series.java
+++ b/src/main/java/com/axibase/tsd/api/model/series/Series.java
@@ -41,10 +41,10 @@ public class Series implements Comparable<Series> {
     }
 
     public Series(String entity, String metric, boolean checkThatEntityAndMetricDoNotExistInAtsd) {
-        if (checkThatEntityAndMetricDoNotExistInAtsd && null != entity) {
+        if (checkThatEntityAndMetricDoNotExistInAtsd && entity != null) {
             Registry.Entity.checkExists(entity);
         }
-        if (checkThatEntityAndMetricDoNotExistInAtsd && null != metric) {
+        if (checkThatEntityAndMetricDoNotExistInAtsd && metric != null) {
             Registry.Metric.checkExists(metric);
         }
         this.entity = entity;
@@ -69,7 +69,11 @@ public class Series implements Comparable<Series> {
     }
 
     public Series(String entity, String metric, String... tags) {
-        this(entity, metric);
+        this(entity, metric, true, tags);
+    }
+
+    public Series(String entity, String metric, boolean checkThatEntityAndMetricDoNotExistInAtsd, String... tags) {
+        this(entity, metric, checkThatEntityAndMetricDoNotExistInAtsd);
 
         /* Tag name-value pairs */
         if (tags.length % 2 != 0) {
@@ -224,8 +228,10 @@ public class Series implements Comparable<Series> {
         if (another.tags ==null || another.tags.isEmpty()) {
             return 1;
         }
-        Iterator<Map.Entry<String, String>> thisIt = this.tags.entrySet().iterator();
-        Iterator<Map.Entry<String, String>> anotherIt = another.tags.entrySet().iterator();
+        TreeMap<String, String> thisTags = new TreeMap<>(this.tags);
+        TreeMap anotherTags = new TreeMap(another.tags);
+        Iterator<Map.Entry<String, String>> thisIt = thisTags.entrySet().iterator();
+        Iterator<Map.Entry<String, String>> anotherIt = anotherTags.entrySet().iterator();
         while (thisIt.hasNext()) {
             if (!anotherIt.hasNext()) {
                 return 1;

--- a/src/main/java/com/axibase/tsd/api/model/series/SeriesMeta.java
+++ b/src/main/java/com/axibase/tsd/api/model/series/SeriesMeta.java
@@ -5,6 +5,7 @@ import com.axibase.tsd.api.model.metric.Metric;
 import com.fasterxml.jackson.annotation.*;
 import lombok.Getter;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -20,7 +21,7 @@ public class SeriesMeta {
     private List<SeriesMetaInfo> series;
 
     @JsonIgnore
-    private Map<String, Object> extraFields;
+    private Map<String, Object> extraFields = new HashMap<>();
 
     @JsonAnyGetter
     public Object getField(String name) {

--- a/src/test/java/com/axibase/tsd/api/method/forecast/ForecastFormTest.java
+++ b/src/test/java/com/axibase/tsd/api/method/forecast/ForecastFormTest.java
@@ -1,0 +1,256 @@
+package com.axibase.tsd.api.method.forecast;
+
+import com.axibase.tsd.api.method.series.SeriesMethod;
+import com.axibase.tsd.api.model.series.Sample;
+import com.axibase.tsd.api.model.series.Series;
+import com.axibase.tsd.api.model.series.SeriesType;
+import com.axibase.tsd.api.model.series.query.SeriesQuery;
+import com.axibase.tsd.api.util.Mocks;
+import com.axibase.tsd.api.util.TimeUtil;
+import lombok.RequiredArgsConstructor;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import javax.ws.rs.core.MultivaluedHashMap;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.Response;
+import java.util.*;
+import java.util.stream.Collectors;
+
+import static com.axibase.tsd.api.method.series.SeriesMethod.querySeriesAsList;
+import static com.axibase.tsd.api.model.series.SeriesType.FORECAST;
+import static com.axibase.tsd.api.model.series.SeriesType.HISTORY;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+import static org.testng.AssertJUnit.assertEquals;
+
+public class ForecastFormTest extends ForecastMethod {
+    private final String startDate = "2021-04-01T00:00:00Z";
+    private final String endDate   = "2021-04-05T00:00:00Z";
+    private final String forecastEndDate   = "2021-04-06T00:00:00Z";
+    private final String entityPrefix= Mocks.entity();
+    private final String entityA= entityPrefix + "_a";
+    private final String entityB = entityPrefix + "_b";
+    private final String tagNameA = "tag-name-1";
+    private final String tagNameB = "tag-name-2";
+    private final String tagValueA = "tag-value-1";
+    private final String tagValueB = "tag-value-2";
+    private final String forecastSettingsName = "forecast-settings-name";
+    private final String specialTagName = "forecast-name";
+
+    @DataProvider
+    public Object[][] testCases() {
+        Object[][] testCases = new Object[6][];
+        addTestCases(testCases, 0, "METRIC_ENTITY_ALL_TAGS", null, Arrays.asList(
+                seriesKey(entityA, tagNameA, tagValueA),
+                seriesKey(entityA, tagNameA, tagValueB),
+                seriesKey(entityA, tagNameA, tagValueA, tagNameB, tagValueB),
+                seriesKey(entityB)
+        ));
+        addTestCases(testCases, 2, "METRIC_ENTITY", null, Arrays.asList(
+                seriesKey(entityA),
+                seriesKey(entityB)
+        ));
+        addTestCases(testCases, 4, "METRIC_ENTITY_DEFINED_TAGS", tagNameA, Arrays.asList(
+                seriesKey(entityA, tagNameA, tagValueA),
+                seriesKey(entityA, tagNameA, tagValueB),
+                seriesKey(entityB)
+        ));
+        System.out.println();
+        return testCases;
+    }
+
+    /**
+     * @param testCases          Collection used to store all test cases.
+     * @param testCaseId         Id to use in assert messages.
+     * @param grouping           How to group series before forecasting.
+     * @param groupingTag        Use as part of a grouping key, to group series with the same value of this tag.
+     * @param expectedSeriesKeys Expected series keys of stored forecasts.
+     */
+    private void addTestCases(Object[][] testCases,
+                              int testCaseId,
+                              String grouping,
+                              String groupingTag,
+                              List<SeriesKey> expectedSeriesKeys) {
+        int id = testCaseId;
+        testCases[id] = new Object[] {id, grouping, groupingTag, true, expectedSeriesKeys};
+        id++;
+        testCases[id] = new Object[] {id, grouping, groupingTag, false, expectedSeriesKeys};
+    }
+
+    @Test(dataProvider = "testCases")
+    public void testFormSubmission(int testCaseId,
+                                   @NotNull String grouping,
+                                   @Nullable String groupingTag,
+                                   /* true - store forecasts under another metric in the series table
+                                    * false - store forecasts under original metric in the forecasts table */
+                                   boolean storeUnderAnotherMetric,
+                                   @NotNull List<SeriesKey> expectedSeriesKeys
+    ) {
+        String caseId = "Test case " + testCaseId + ". ";
+
+        /* In each test case we do forecasts for the same set of series,
+           but each time with a new metric,
+           otherwise forecasts from later test cases will be mixed
+           with forecasts stored during previous test cases. */
+        String metric = Mocks.metric();
+        insertSeries(metric);
+
+        /* Calculate and store forecasts. */
+        String producedMetric = storeUnderAnotherMetric ? "mock-" + metric : null;
+        Response forecastResponse = sendForecastFormData(formData(metric, grouping, groupingTag, producedMetric));
+        int statusCode = forecastResponse.getStatus();
+        assertEquals(caseId + "Test case Forecast request failed with status code " + statusCode, statusCode, Response.Status.OK.getStatusCode());
+
+        /* Get stored forecasts, and wait a bit if stored forecasts count differs from expected,
+           because ATSD may need some time to actually store forecasts.
+           Also if forecasts are not stored the response can contains empty series,
+           so need check that series in response are not empty.
+        */
+        List<Series> actualSeriesList = null;
+        for (int i = 0; i < 20; i++) {
+            try {
+                Thread.sleep(500);
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+            actualSeriesList = loadStoredForecasts(metric, producedMetric);
+            if (expectedSeriesKeys.size() == actualSeriesList.size() &&
+                actualSeriesList.stream().noneMatch(series -> series.getData().isEmpty())) {
+                break;
+            }
+        }
+        assertNotNull(actualSeriesList);
+        assertEquals(caseId, expectedSeriesKeys.size(), actualSeriesList.size());
+
+        /* Sort actual series by metric, entity, and tags to be able to compare them with expected in correct order. */
+        Collections.sort(actualSeriesList);
+
+        /* Convert expected series keys to expected series appending suitable metric and tag to each key. */
+        SeriesType type = storeUnderAnotherMetric ? HISTORY : FORECAST;
+        List<Series> expectedSeriesList = expectedSeriesKeys.stream()
+                .map(key -> toExpectedSeries(metric, producedMetric, type, key))
+                .sorted()
+                .collect(Collectors.toList());
+
+        int size = expectedSeriesList.size();
+        for (int i = 0; i < size; i++) {
+            String seriesIndex = "Series index = " + i + ". ";
+            Series expectedSeries = expectedSeriesList.get(i);
+            Series actualSeries = actualSeriesList.get(i);
+            // check metric, entity and tags
+            assertTrue(expectedSeries.compareTo(actualSeries) == 0, caseId + seriesIndex);
+            assertEquals(caseId + seriesIndex, expectedSeries.getType(), actualSeries.getType());
+            if (expectedSeries.getType() == FORECAST) {
+                assertEquals(caseId + seriesIndex, forecastSettingsName, actualSeries.getForecastName());
+            }
+            assertEquals(caseId + seriesIndex, 6, actualSeries.getData().size());
+        }
+    }
+
+    private void insertSeries(String metric) {
+        List<Series> seriesList = Arrays.asList(
+                new Series(entityA, metric, false, tagNameA, tagValueA),
+                new Series(entityA, metric, false, tagNameA, tagValueB),
+                new Series(entityA, metric, false, tagNameA, tagValueA, tagNameB, tagValueB),
+                new Series(entityB, metric, false)
+        );
+
+        /*
+           Add the same samples to each of the series.
+           Each series has a sample with value 1 every minute from startDate until endDate.
+         */
+        List<Sample> samples = new ArrayList<>();
+        long millis = TimeUtil.epochMillis(startDate);
+        long endMillis = TimeUtil.epochMillis(endDate);
+        int value = 1;
+        while (millis < endMillis) {
+            samples.add(Sample.ofTimeInteger(millis, value++));
+            millis += 60_000;
+        }
+        seriesList.forEach(series -> series.addSamples(samples));
+
+        SeriesMethod.insertSeries(seriesList);
+    }
+
+    private MultivaluedMap<String, String> formData(@NotNull String metric,
+                                                    @NotNull String grouping,
+                                                    @Nullable String groupingTag,
+                                                    @Nullable String producedMetric) {
+        MultivaluedMap<String, String> formData = new MultivaluedHashMap<>();
+        formData.add("settings.startTime", startDate);
+        formData.add("settings.endTime", endDate);
+        formData.add("settings.metric", metric);
+        formData.add("settings.entity", entityPrefix + "*"); // request all 4 series
+        formData.add("groupingType", grouping);
+        formData.add("settings.requiredTagKeys", groupingTag);
+        formData.add("settings.averagingInterval.intervalCount", "10");
+        formData.add("settings.averagingInterval.intervalUnit", "MINUTE");
+        formData.add("settings.aggregateStatistics", "SUM");
+        formData.add("settings.algorithm", "SSA");
+        formData.add("settings.ssaComponentCount", "3");
+        formData.add("settings.scoreInterval.intervalCount", "60");
+        formData.add("settings.scoreInterval.intervalUnit", "MINUTE");
+        formData.add("_settings.autoPeriod", "on");
+        formData.add("settings.autoPeriod", "on");
+        formData.add("_settings.autoParameters", "on");
+        formData.add("settings.autoParameters", "on");
+        formData.add("settings.name", forecastSettingsName);
+        formData.add("settings.storeInterval.intervalCount", "60");   // forecast horizon
+        formData.add("settings.storeInterval.intervalUnit", "MINUTE");
+        formData.add("settings.producedMetric", producedMetric);
+        formData.add("forecast", "Run");
+        return formData;
+    }
+
+    private List<Series> loadStoredForecasts(@NotNull String metric, @Nullable String producedMetric) {
+        List<Series> seriesList = new ArrayList<>(4);
+        seriesList.addAll(querySeriesAsList(query(metric, entityA, producedMetric)));
+        seriesList.addAll(querySeriesAsList(query(metric, entityB, producedMetric)));
+        return seriesList;
+    }
+
+    private SeriesQuery query(@NotNull String metric, @NotNull String entity, @Nullable String producedMetric) {
+        SeriesQuery query = new SeriesQuery();
+        query.setEntity(entity);
+        query.setStartDate(startDate);
+        query.setEndDate(forecastEndDate);
+        if (producedMetric == null) {
+            query.setType(FORECAST);
+            query.setForecastName(forecastSettingsName);
+            query.setMetric(metric);
+        } else {
+            query.setType(HISTORY);
+            query.setMetric(producedMetric);
+        }
+        return query;
+    }
+
+    private SeriesKey seriesKey(String entity, String... tags) {
+        Map<String, String> tagsMap = new HashMap<>();
+        for (int i = 0; i < tags.length / 2; i++) {
+            tagsMap.put(tags[2 * i], tags[2 * i + 1]);
+        }
+        return new SeriesKey(entity, tagsMap);
+    }
+
+    @RequiredArgsConstructor
+    private final class SeriesKey {
+        private final String entity;
+        private final Map<String, String> tags;
+    }
+
+    private Series toExpectedSeries(String metric, String producedMetric, SeriesType seriesType, SeriesKey seriesKey) {
+        String actualMetric = seriesType == FORECAST ? metric : producedMetric;
+        Series series = new Series(seriesKey.entity, actualMetric, false);
+        series.setTags(new HashMap<>(seriesKey.tags));
+        if (seriesType == HISTORY) {
+            series.addTag(specialTagName, forecastSettingsName);
+        } else {
+            series.setType(FORECAST);
+        }
+        return series;
+    }
+}

--- a/src/test/java/com/axibase/tsd/api/method/forecast/ForecastFormTest.java
+++ b/src/test/java/com/axibase/tsd/api/method/forecast/ForecastFormTest.java
@@ -58,7 +58,6 @@ public class ForecastFormTest extends ForecastMethod {
                 seriesKey(entityA, tagNameA, tagValueB),
                 seriesKey(entityB)
         ));
-        System.out.println();
         return testCases;
     }
 

--- a/src/test/java/com/axibase/tsd/api/method/forecast/ForecastFormTest.java
+++ b/src/test/java/com/axibase/tsd/api/method/forecast/ForecastFormTest.java
@@ -159,7 +159,7 @@ public class ForecastFormTest extends ForecastMethod {
 
         /*
            Add the same samples to each of the series.
-           Each series has a sample with value 1 every minute from startDate until endDate.
+           Each series has a sample every minute from startDate until endDate.
          */
         List<Sample> samples = new ArrayList<>();
         long millis = TimeUtil.epochMillis(startDate);


### PR DESCRIPTION
A Forecast Job /forecast/settings/edit.xhtml
allows to group requested series, calculate a forecast for each group, and store the forecast either
in series table or in forecast table under specified metric.
The test checks, that those forecasts are actually stored in suitable table, and with correct series keys.

Sasha, could you please merge this PR, if you accept it.